### PR TITLE
Uniform Sampling from XOF

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sha3"]
+	path = sha3
+	url = https://github.com/itzmeanjan/sha3.git

--- a/include/bit_packing.hpp
+++ b/include/bit_packing.hpp
@@ -33,4 +33,28 @@ encode(const ff::ff_t* const __restrict poly, uint8_t* const __restrict arr)
   }
 }
 
+// Given a byte array of length 32 * sbw -bytes, this routine attempts to
+// extract out 256 coefficients of degree-255 polynomial s.t. significant
+// portion of each coefficient ∈ [0, 2^sbw)
+template<const size_t sbw>
+static void
+decode(const uint8_t* const __restrict arr, ff::ff_t* const __restrict poly)
+{
+  constexpr size_t blen = ntt::N * sbw;
+  constexpr size_t len = blen >> 3;
+
+  std::memset(poly, 0, ntt::N * sizeof(ff::ff_t));
+
+  for (size_t i = 0; i < blen; i++) {
+    const size_t aidx = i >> 3;
+    const size_t aoff = i & 7ul;
+
+    const size_t pidx = i / sbw;
+    const size_t poff = i % sbw;
+
+    const uint8_t bit = (arr[aidx] >> aoff) & 0b1;
+    poly[pidx].v = poly[pidx].v ^ static_cast<uint32_t>(bit) << poff;
+  }
+}
+
 }

--- a/include/bit_packing.hpp
+++ b/include/bit_packing.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include "ntt.hpp"
+#include <cstring>
+
+// Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
+namespace dilithium_utils {
+
+// Given a degree-255 polynomial, where significant portion of each ( total 256
+// of them ) coefficient ∈ [0, 2^sbw), this routine serializes the polynomial to
+// a byte array of length 32 * sbw -bytes
+//
+// See section 5.2 ( which describes bit packing ) of Dilithium specification,
+// as submitted to NIST final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+template<const size_t sbw>
+static void
+encode(const ff::ff_t* const __restrict poly, uint8_t* const __restrict arr)
+{
+  constexpr size_t blen = ntt::N * sbw;
+  constexpr size_t len = blen >> 3;
+
+  std::memset(arr, 0, len);
+
+  for (size_t i = 0; i < blen; i++) {
+    const size_t pidx = i / sbw;
+    const size_t poff = i % sbw;
+
+    const size_t aidx = i >> 3;
+    const size_t aoff = i & 7ul;
+
+    const uint8_t bit = static_cast<uint8_t>((poly[pidx].v >> poff) & 0b1);
+    arr[aidx] = arr[aidx] ^ (bit << aoff);
+  }
+}
+
+}

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include "ntt.hpp"
+#include "reduction.hpp"
+
+// Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
+namespace dilithium_utils {
+
+// Given a degree-255 polynomial over Z_q | q = 2^23 - 2^13 + 1, this routine
+// attempts to extract out high and low order bits from each of 256 coefficients
+template<const size_t d>
+static void
+poly_power2round(const ff::ff_t* const __restrict poly,
+                 ff::ff_t* const __restrict poly_hi,
+                 ff::ff_t* const __restrict poly_lo) requires(check_d(d))
+{
+  for (size_t i = 0; i < ntt::N; i++) {
+    const auto ext = power2round<d>(poly[i]);
+
+    poly_hi[i] = ext.first;
+    poly_lo[i] = ext.second;
+  }
+}
+
+}

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -21,4 +21,16 @@ poly_power2round(const ff::ff_t* const __restrict poly,
   }
 }
 
+// Given two degree-255 polynomials in NTT representation, this routine performs
+// element-wise multiplication over Z_q | q = 2^23 - 2^13 + 1
+static void
+polymul(const ff::ff_t* const __restrict polya,
+        const ff::ff_t* const __restrict polyb,
+        ff::ff_t* const __restrict polyc)
+{
+  for (size_t i = 0; i < ntt::N; i++) {
+    polyc[i] = polya[i] * polyb[i];
+  }
+}
+
 }

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "bit_packing.hpp"
 #include "poly.hpp"
 
 // Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
@@ -95,6 +96,38 @@ polyvec_add_to(const ff::ff_t* const __restrict src,
     for (size_t l = 0; l < ntt::N; l++) {
       dst[off + l] = dst[off + l] + src[off + l];
     }
+  }
+}
+
+// Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
+// encodes each of those polynomials into 32 x sbw -bytes, writing to a
+// (k x 32 x sbw) -bytes destination array
+template<const size_t k, const size_t sbw>
+inline static void
+polyvec_encode(const ff::ff_t* const __restrict src,
+               uint8_t* const __restrict dst)
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off0 = i * ntt::N;
+    const size_t off1 = i * sbw * 32;
+
+    encode<sbw>(src + off0, dst + off1);
+  }
+}
+
+// Given a byte array of length (k x 32 x sbw) -bytes, this routine decodes them
+// into k degree-255 polynomials, writing them to a column vector of dimension
+// k x 1
+template<const size_t k, const size_t sbw>
+inline static void
+polyvec_decode(const uint8_t* const __restrict src,
+               ff::ff_t* const __restrict dst)
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off0 = i * sbw * 32;
+    const size_t off1 = i * ntt::N;
+
+    decode<sbw>(src + off0, dst + off1);
   }
 }
 

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "poly.hpp"
+
+// Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
+namespace dilithium_utils {
+
+// Applies NTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
+template<const size_t k>
+static void
+polyvec_ntt(ff::ff_t* const __restrict vec)
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+    ntt::ntt(vec + off);
+  }
+}
+
+// Applies iNTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
+template<const size_t k>
+static void
+polyvec_intt(ff::ff_t* const __restrict vec)
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+    ntt::intt(vec + off);
+  }
+}
+
+}

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -6,7 +6,7 @@ namespace dilithium_utils {
 
 // Applies NTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
 template<const size_t k>
-static void
+inline static void
 polyvec_ntt(ff::ff_t* const __restrict vec)
 {
   for (size_t i = 0; i < k; i++) {
@@ -17,7 +17,7 @@ polyvec_ntt(ff::ff_t* const __restrict vec)
 
 // Applies iNTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
 template<const size_t k>
-static void
+inline static void
 polyvec_intt(ff::ff_t* const __restrict vec)
 {
   for (size_t i = 0; i < k; i++) {
@@ -29,7 +29,7 @@ polyvec_intt(ff::ff_t* const __restrict vec)
 // Compresses vector ( of dimension k x 1 ) of degree-255 polynomials by
 // extracting out high and low order bits
 template<const size_t k, const size_t d>
-static void
+inline static void
 polyvec_power2round(const ff::ff_t* const __restrict poly,
                     ff::ff_t* const __restrict poly_hi,
                     ff::ff_t* const __restrict poly_lo) requires(check_d(d))
@@ -77,6 +77,23 @@ matrix_multiply(const ff::ff_t* const __restrict a,
           c[coff + l] = c[coff + l] + tmp[l];
         }
       }
+    }
+  }
+}
+
+// Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this
+// routine adds it to another polynomial vector of same dimension s.t.
+// destination vector is mutated.
+template<const size_t k>
+inline static void
+polyvec_add_to(const ff::ff_t* const __restrict src,
+               ff::ff_t* const __restrict dst)
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    for (size_t l = 0; l < ntt::N; l++) {
+      dst[off + l] = dst[off + l] + src[off + l];
     }
   }
 }

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -26,4 +26,18 @@ polyvec_intt(ff::ff_t* const __restrict vec)
   }
 }
 
+// Compresses vector ( of dimension k x 1 ) of degree-255 polynomials by
+// extracting out high and low order bits
+template<const size_t k, const size_t d>
+static void
+polyvec_power2round(const ff::ff_t* const __restrict poly,
+                    ff::ff_t* const __restrict poly_hi,
+                    ff::ff_t* const __restrict poly_lo) requires(check_d(d))
+{
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+    poly_power2round<d>(poly + off, poly_hi + off, poly_lo + off);
+  }
+}
+
 }

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -40,4 +40,45 @@ polyvec_power2round(const ff::ff_t* const __restrict poly,
   }
 }
 
+// Compile-time check to ensure that operand matrices are having compatible
+// dimension for matrix multiplication
+static inline constexpr bool
+check_matrix_dim(const size_t a_cols, const size_t b_rows)
+{
+  return !static_cast<bool>(a_cols ^ b_rows);
+}
+
+// Given two matrices ( in NTT domain ) of compatible dimension, where each
+// matrix element is a degree-255 polynomial over Z_q | q = 2^23 -2^13 + 1, this
+// routine attempts to multiply and compute resulting matrix
+template<const size_t a_rows,
+         const size_t a_cols,
+         const size_t b_rows,
+         const size_t b_cols>
+static void
+matrix_multiply(const ff::ff_t* const __restrict a,
+                const ff::ff_t* const __restrict b,
+                ff::ff_t* const __restrict c) requires(check_matrix_dim(a_cols,
+                                                                        b_rows))
+{
+  ff::ff_t tmp[ntt::N]{};
+
+  for (size_t i = 0; i < a_rows; i++) {
+    for (size_t j = 0; j < b_cols; j++) {
+      const size_t coff = (i * b_cols + j) * ntt::N;
+
+      for (size_t k = 0; k < a_cols; k++) {
+        const size_t aoff = (i * a_cols + k) * ntt::N;
+        const size_t boff = (k * b_cols + j) * ntt::N;
+
+        polymul(a + coff, b + boff, tmp);
+
+        for (size_t l = 0; l < ntt::N; l++) {
+          c[coff + l] = c[coff + l] + tmp[l];
+        }
+      }
+    }
+  }
+}
+
 }

--- a/include/reduction.hpp
+++ b/include/reduction.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include "ff.hpp"
+#include "utility"
+
+// Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
+namespace dilithium_utils {
+
+// Compile-time check to ensure that number of bits to be dropped from a
+// polynomial coefficient is supplied correctly.
+inline static constexpr bool
+check_d(const size_t d)
+{
+  return d == 13;
+}
+
+// Given an element of Z_q | q = 2^23 - 2^13 + 1, this routine extracts out high
+// and low order bits, using modulo of power of 2 ( = 2^d ), so that public key
+// can be compressed.
+//
+// See definition of this routine in figure 3 of Dilithium specification, as
+// submitted to NIST final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+template<const size_t d>
+inline static std::pair<ff::ff_t, ff::ff_t>
+power2round(const ff::ff_t r) requires(check_d(d))
+{
+  constexpr uint32_t mask = (1u << d) - 1u;
+
+  const uint32_t t0 = r.v >> d;
+  const uint32_t t1 = r.v & mask;
+
+  return std::make_pair(ff::ff_t{ t0 }, ff::ff_t{ t1 });
+}
+
+}

--- a/include/sampling.hpp
+++ b/include/sampling.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include "ff.hpp"
+#include "ntt.hpp"
+#include "shake128.hpp"
+#include <cstring>
+
+// Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
+namespace dilithium_utils {
+
+// Given a 32 -bytes uniform seed ρ, a k x l matrix is deterministically
+// sampled, where each coefficient is a degree-255 polynomial ∈ R_q
+// | q = 2^23 - 2^13 + 1
+//
+// SHAKE128 XOF is used for expanding 32 -bytes seed to matrix over R_q^(k x l).
+//
+// See `Expanding the Matrix A` point in section 5.3 of Dilithium specification,
+// as submitted to NIST final round call
+// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+template<const size_t k, const size_t l>
+static void
+expand_a(const uint8_t* const __restrict rho, ff::ff_t* const __restrict mat)
+{
+  uint8_t msg[34];
+  uint8_t buf[3];
+
+  std::memcpy(msg, rho, 32);
+
+  for (size_t i = 0; i < k; i++) {
+    for (size_t j = 0; j < l; j++) {
+      const size_t off = (i * k + j) * ntt::N;
+
+      msg[32] = j;
+      msg[33] = i;
+
+      shake128::shake128 hasher{};
+      hasher.hash(msg, sizeof(msg));
+
+      size_t n = 0;
+      while (n < ntt::N) {
+        hasher.read(buf, sizeof(buf));
+
+        const uint32_t t0 = static_cast<uint32_t>(buf[2] & 0b01111111);
+        const uint32_t t1 = static_cast<uint32_t>(buf[1]);
+        const uint32_t t2 = static_cast<uint32_t>(buf[0]);
+
+        const uint32_t t3 = (t0 << 16) ^ (t1 << 8) ^ (t0 << 0);
+        const bool flg = t3 < ff::Q;
+
+        mat[off + n] = ff::ff_t{ static_cast<uint32_t>(t3 * flg) };
+        n = n + flg * 1;
+      }
+    }
+  }
+}
+
+}

--- a/include/sampling.hpp
+++ b/include/sampling.hpp
@@ -2,6 +2,7 @@
 #include "ff.hpp"
 #include "ntt.hpp"
 #include "shake128.hpp"
+#include "shake256.hpp"
 #include <cstring>
 
 // Utility functions for Dilithium Post-Quantum Digital Signature Algorithm
@@ -48,6 +49,89 @@ expand_a(const uint8_t* const __restrict rho, ff::ff_t* const __restrict mat)
 
         mat[off + n] = ff::ff_t{ static_cast<uint32_t>(t3 * flg) };
         n = n + flg * 1;
+      }
+    }
+  }
+}
+
+// Compile-time check to ensure that η ∈ {2, 4}, so that sampled secret key
+// range stays short i.e. [-η, η]
+inline static constexpr bool
+check_eta(const uint32_teta)
+{
+  return (eta == 2u) || (eta == 4u);
+}
+
+// Compile-time check to ensure that starting nonce belongs to allowed set of
+// values when uniform sampling polynomial coefficients in [-η, η]
+inline static constexpr bool
+check_nonce(const size_t nonce)
+{
+  return (nonce == 0) || (nonce == 4) || (nonce == 5) || (nonce == 7);
+}
+
+// Uniform sampling k -many degree-255 polynomials s.t. each coefficient of
+// those polynomials belong to [-η, η].
+//
+// Sampling is performed deterministically, by seeding SHAKE256 XOF with
+// 32 -bytes seed and single byte nonce, whose starting value is provided ( see
+// template parameter ). Consecutive nonces are computed by adding 1 to previous
+// one.
+//
+// Rejection sampling logic is adapted from
+// https://github.com/pq-crystals/dilithium/blob/3e9b9f1/ref/poly.c#L370-L417
+//
+// Note, sampled polynomial coefficients are kept in canonical form.
+template<const uint32_t eta, const size_t k, const size_t nonce>
+static void
+uniform_sample_eta(const uint8_t* const __restrict sigma,
+                   ff::ff_t* const __restrict vec) requires(check_eta(eta) &&
+                                                            check_nonce(nonce))
+{
+  uint8_t msg[33];
+  uint8_t buf;
+
+  std::memcpy(msg, sigma, 32);
+
+  for (size_t i = 0; i < k; i++) {
+    const size_t off = i * ntt::N;
+
+    msg[32] = nonce + i;
+
+    shake256::shake256 hasher{};
+    hasher.hash(msg, sizeof(msg));
+
+    size_t n = 0;
+    while (n < ntt::N) {
+      hasher.read(&buf, 1);
+
+      const uint8_t t0 = buf & 0x0f;
+      const uint8_t t1 = buf >> 4;
+
+      if constexpr (eta == 2u) {
+        if (t0 < 15) {
+          const uint32_t t2 = static_cast<uint32_t>(t0 % 5);
+
+          vec[off + n] = ff::ff_t{ 2u } - ff::ff_t{ t2 };
+          n += 1;
+        }
+
+        if ((t1 < 15) && (n < ntt::N)) {
+          const uint32_t t2 = static_cast<uint32_t>(t1 % 5);
+
+          vec[off + n] = ff::ff_t{ 2u } - ff::ff_t{ t2 };
+          n += 1;
+        }
+      } else {
+        if (t0 < 9) {
+          vec[off + n] = ff::ff_t{ 4u } - ff::ff_t{ static_cast<uint32_t>(t0) };
+          n += 1;
+        }
+
+        if ((t1 < 9) && (n < ntt::N)) {
+          vec[off + n] = ff::ff_t{ 4u } - ff::ff_t{ static_cast<uint32_t>(t1) };
+          n += 1;
+        }
       }
     }
   }


### PR DESCRIPTION
- Expand matrix A from SHAKE128, seeded with 32 -bytes and 1 -byte nonce
- Uniformly sample in `[-η, η]`, for deterministically computing short vectors (**s1**, **s2**) [ Private Keys ]
- Bit packing of vector of degree-255 polynomials to byte arrays
- Reverse of above i.e. bit unpacking has also been implemented 