### PR TITLE
Benchmark Dilithium KeyGen, Signing and Verification

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -32,6 +32,9 @@ BENCHMARK(bench_dilithium::uniform_sampling_eta<4, 6>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 17, 4>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 19, 5>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 19, 7>);
+BENCHMARK(bench_dilithium::sample_in_ball<39>);
+BENCHMARK(bench_dilithium::sample_in_ball<49>);
+BENCHMARK(bench_dilithium::sample_in_ball<60>);
 
 // register for benchmarking serialization/ deserialization of polynomials
 BENCHMARK(bench_dilithium::encode<3>);

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -29,10 +29,24 @@ BENCHMARK(bench_dilithium::encode<3>);
 BENCHMARK(bench_dilithium::decode<3>);
 BENCHMARK(bench_dilithium::encode<4>);
 BENCHMARK(bench_dilithium::decode<4>);
+BENCHMARK(bench_dilithium::encode<6>);
+BENCHMARK(bench_dilithium::decode<6>);
 BENCHMARK(bench_dilithium::encode<10>);
 BENCHMARK(bench_dilithium::decode<10>);
 BENCHMARK(bench_dilithium::encode<13>);
 BENCHMARK(bench_dilithium::decode<13>);
+BENCHMARK(bench_dilithium::encode<18>);
+BENCHMARK(bench_dilithium::decode<18>);
+BENCHMARK(bench_dilithium::encode<20>);
+BENCHMARK(bench_dilithium::decode<20>);
+
+// register for benchmarking serialization/ deserialization of hint bits
+BENCHMARK(bench_dilithium::encode_hint_bits<4, 80>);
+BENCHMARK(bench_dilithium::decode_hint_bits<4, 80>);
+BENCHMARK(bench_dilithium::encode_hint_bits<6, 55>);
+BENCHMARK(bench_dilithium::decode_hint_bits<6, 55>);
+BENCHMARK(bench_dilithium::encode_hint_bits<8, 75>);
+BENCHMARK(bench_dilithium::decode_hint_bits<8, 75>);
 
 // register for benchmarking Dilithium Key Generation Algorithm
 BENCHMARK(bench_dilithium::keygen<4, 4, 2, 13>); // NIST security level 2

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -29,6 +29,9 @@ BENCHMARK(bench_dilithium::expand_a<8, 7>);
 BENCHMARK(bench_dilithium::uniform_sampling_eta<2, 4>);
 BENCHMARK(bench_dilithium::uniform_sampling_eta<2, 8>);
 BENCHMARK(bench_dilithium::uniform_sampling_eta<4, 6>);
+BENCHMARK(bench_dilithium::expand_mask<1u << 17, 4>);
+BENCHMARK(bench_dilithium::expand_mask<1u << 19, 5>);
+BENCHMARK(bench_dilithium::expand_mask<1u << 19, 7>);
 
 // register for benchmarking serialization/ deserialization of polynomials
 BENCHMARK(bench_dilithium::encode<3>);

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -60,10 +60,13 @@ BENCHMARK(bench_dilithium::decode_hint_bits<6, 55>);
 BENCHMARK(bench_dilithium::encode_hint_bits<8, 75>);
 BENCHMARK(bench_dilithium::decode_hint_bits<8, 75>);
 
-// register for benchmarking Dilithium Key Generation Algorithm
-BENCHMARK(bench_dilithium::keygen<4, 4, 2, 13>); // NIST security level 2
-BENCHMARK(bench_dilithium::keygen<6, 5, 4, 13>); // NIST security level 3
-BENCHMARK(bench_dilithium::keygen<8, 7, 2, 13>); // NIST security level 5
+// register for benchmarking Dilithium Key Generation, Signing Algorithm
+BENCHMARK(bench_dilithium::keygen<4, 4, 13, 2>);
+BENCHMARK(bench_dilithium::sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>);
+BENCHMARK(bench_dilithium::keygen<6, 5, 13, 4>);
+BENCHMARK(bench_dilithium::sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>);
+BENCHMARK(bench_dilithium::keygen<8, 7, 13, 2>);
+BENCHMARK(bench_dilithium::sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>);
 
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -60,13 +60,16 @@ BENCHMARK(bench_dilithium::decode_hint_bits<6, 55>);
 BENCHMARK(bench_dilithium::encode_hint_bits<8, 75>);
 BENCHMARK(bench_dilithium::decode_hint_bits<8, 75>);
 
-// register for benchmarking Dilithium Key Generation, Signing Algorithm
-BENCHMARK(bench_dilithium::keygen<4, 4, 13, 2>);
+// register for benchmarking Dilithium Key Generation, Signing & Verification
+BENCHMARK(bench_dilithium::keygen<4, 4, 13, 2>); // NIST security level 2
 BENCHMARK(bench_dilithium::sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>);
-BENCHMARK(bench_dilithium::keygen<6, 5, 13, 4>);
+BENCHMARK(bench_dilithium::verify<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>);
+BENCHMARK(bench_dilithium::keygen<6, 5, 13, 4>); // NIST security level 3
 BENCHMARK(bench_dilithium::sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>);
-BENCHMARK(bench_dilithium::keygen<8, 7, 13, 2>);
+BENCHMARK(bench_dilithium::verify<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>);
+BENCHMARK(bench_dilithium::keygen<8, 7, 13, 2>); // NIST security level 5
 BENCHMARK(bench_dilithium::sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>);
+BENCHMARK(bench_dilithium::verify<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>);
 
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -15,6 +15,12 @@ BENCHMARK(bench_dilithium::intt);
 
 // register for benchmarking coefficient reduction techniques
 BENCHMARK(bench_dilithium::power2round);
+BENCHMARK(bench_dilithium::decompose<190464>);
+BENCHMARK(bench_dilithium::make_hint<190464>);
+BENCHMARK(bench_dilithium::use_hint<190464>);
+BENCHMARK(bench_dilithium::decompose<523776>);
+BENCHMARK(bench_dilithium::make_hint<523776>);
+BENCHMARK(bench_dilithium::use_hint<523776>);
 
 // register for benchmarking sampling vector/ matrix from XOF
 BENCHMARK(bench_dilithium::expand_a<4, 4>);

--- a/include/bench_bit_packing.hpp
+++ b/include/bench_bit_packing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "bit_packing.hpp"
+#include "test_bit_packing.hpp"
 #include <benchmark/benchmark.h>
 #include <cassert>
 
@@ -86,6 +87,83 @@ decode(benchmark::State& state)
   std::free(polya);
   std::free(polyb);
   std::free(arr);
+}
+
+// Benchmark encoding of vector ( of dimension k x 1 ) of degree-255 polynomials
+// ( with hint bits ) to byte array to length (ω + k) s.t. there are at max ω
+// -many set bits in hint bit array.
+template<const size_t k, const size_t ω>
+void
+encode_hint_bits(benchmark::State& state)
+{
+  constexpr size_t hlen = sizeof(ff::ff_t) * k * ntt::N;
+  constexpr size_t alen = ω + k;
+
+  ff::ff_t* h0 = static_cast<ff::ff_t*>(std::malloc(hlen));
+  ff::ff_t* h1 = static_cast<ff::ff_t*>(std::malloc(hlen));
+  uint8_t* arr = static_cast<uint8_t*>(std::malloc(alen));
+
+  test_dilithium::generate_random_hint_bits<k, ω>(h0);
+
+  for (auto _ : state) {
+    dilithium_utils::encode_hint_bits<k, ω>(h0, arr);
+
+    benchmark::DoNotOptimize(h0);
+    benchmark::DoNotOptimize(arr);
+    benchmark::ClobberMemory();
+  }
+
+  const bool failed = dilithium_utils::decode_hint_bits<k, ω>(arr, h1);
+  bool flg = true;
+
+  for (size_t i = 0; i < k * ntt::N; i++) {
+    flg &= (h0[i] == h1[i]);
+  }
+
+  std::free(h0);
+  std::free(h1);
+  std::free(arr);
+
+  assert(flg & !failed);
+}
+
+// Benchmark decoding of byte array of lenth (ω + k) to a vector ( of dimension
+// k x 1 ) of degree-255 polynomials ( with hint bits ) s.t. there are at max ω
+// -many set bits in hint bit array.
+template<const size_t k, const size_t ω>
+void
+decode_hint_bits(benchmark::State& state)
+{
+  constexpr size_t hlen = sizeof(ff::ff_t) * k * ntt::N;
+  constexpr size_t alen = ω + k;
+
+  ff::ff_t* h0 = static_cast<ff::ff_t*>(std::malloc(hlen));
+  ff::ff_t* h1 = static_cast<ff::ff_t*>(std::malloc(hlen));
+  uint8_t* arr = static_cast<uint8_t*>(std::malloc(alen));
+
+  test_dilithium::generate_random_hint_bits<k, ω>(h0);
+  dilithium_utils::encode_hint_bits<k, ω>(h0, arr);
+
+  for (auto _ : state) {
+    const bool failed = dilithium_utils::decode_hint_bits<k, ω>(arr, h1);
+    assert(!failed);
+
+    benchmark::DoNotOptimize(failed);
+    benchmark::DoNotOptimize(arr);
+    benchmark::DoNotOptimize(h1);
+    benchmark::ClobberMemory();
+  }
+
+  bool flg = true;
+  for (size_t i = 0; i < k * ntt::N; i++) {
+    flg &= (h0[i] == h1[i]);
+  }
+
+  std::free(h0);
+  std::free(h1);
+  std::free(arr);
+
+  assert(flg);
 }
 
 }

--- a/include/bench_dilithium.hpp
+++ b/include/bench_dilithium.hpp
@@ -6,3 +6,4 @@
 #include "bench_reduction.hpp"
 #include "bench_sampling.hpp"
 #include "bench_signing.hpp"
+#include "bench_verification.hpp"

--- a/include/bench_dilithium.hpp
+++ b/include/bench_dilithium.hpp
@@ -5,3 +5,4 @@
 #include "bench_ntt.hpp"
 #include "bench_reduction.hpp"
 #include "bench_sampling.hpp"
+#include "bench_signing.hpp"

--- a/include/bench_keygen.hpp
+++ b/include/bench_keygen.hpp
@@ -6,7 +6,7 @@
 // Benchmark Dilithium PQC suite implementation on CPU, using google-benchmark
 namespace bench_dilithium {
 
-// Benchmark Dilithium Key Generation Algorithm, for different parameter sets
+// Benchmark Dilithium Key Generation Algorithm
 template<const size_t k, const size_t l, const size_t d, const uint32_t η>
 void
 keygen(benchmark::State& state)

--- a/include/bench_keygen.hpp
+++ b/include/bench_keygen.hpp
@@ -7,7 +7,7 @@
 namespace bench_dilithium {
 
 // Benchmark Dilithium Key Generation Algorithm, for different parameter sets
-template<const size_t k, const size_t l, const uint32_t η, const size_t d>
+template<const size_t k, const size_t l, const size_t d, const uint32_t η>
 void
 keygen(benchmark::State& state)
 {
@@ -22,7 +22,7 @@ keygen(benchmark::State& state)
   dilithium_utils::random_data<uint8_t>(seed, slen);
 
   for (auto _ : state) {
-    dilithium::keygen<k, l, η, d>(seed, pubkey, seckey);
+    dilithium::keygen<k, l, d, η>(seed, pubkey, seckey);
 
     benchmark::DoNotOptimize(seed);
     benchmark::DoNotOptimize(pubkey);

--- a/include/bench_reduction.hpp
+++ b/include/bench_reduction.hpp
@@ -24,4 +24,65 @@ power2round(benchmark::State& state)
   }
 }
 
+// Benchmark decompose routine, with randomly generated Z_q element
+// | q = 2^23 - 2^13 + 1
+template<const uint32_t alpha>
+void
+decompose(benchmark::State& state)
+{
+  ff::ff_t r = ff::ff_t::random();
+
+  for (auto _ : state) {
+    const auto s = dilithium_utils::decompose<alpha>(r);
+
+    benchmark::DoNotOptimize(r);
+    benchmark::DoNotOptimize(s);
+    benchmark::ClobberMemory();
+  }
+}
+
+// Benchmarks performance of computation of hint bit, given one arbitrary Z_q
+// element r and another small Z_q element z
+template<const uint32_t alpha>
+void
+make_hint(benchmark::State& state)
+{
+  constexpr uint32_t m = (ff::Q - 1u) / alpha;
+  constexpr ff::ff_t z{ m - 1u };
+
+  ff::ff_t r = ff::ff_t::random();
+
+  for (auto _ : state) {
+    const ff::ff_t h = dilithium_utils::make_hint<alpha>(z, r);
+
+    benchmark::DoNotOptimize(z);
+    benchmark::DoNotOptimize(r);
+    benchmark::DoNotOptimize(h);
+    benchmark::ClobberMemory();
+  }
+}
+
+// Benchmarks performance of routine which uses hint bit and attempts to recover
+// high order bits of r + z s.t. r is arbitrary element ∈	Z_q and z is
+// small element ∈ Z_q
+template<const uint32_t alpha>
+void
+use_hint(benchmark::State& state)
+{
+  constexpr uint32_t m = (ff::Q - 1u) / alpha;
+  constexpr ff::ff_t z{ m - 1u };
+
+  ff::ff_t r = ff::ff_t::random();
+  ff::ff_t h = dilithium_utils::make_hint<alpha>(z, r);
+
+  for (auto _ : state) {
+    const ff::ff_t rz = dilithium_utils::use_hint<alpha>(h, r);
+
+    benchmark::DoNotOptimize(h);
+    benchmark::DoNotOptimize(r);
+    benchmark::DoNotOptimize(rz);
+    benchmark::ClobberMemory();
+  }
+}
+
 }

--- a/include/bench_sampling.hpp
+++ b/include/bench_sampling.hpp
@@ -90,4 +90,29 @@ expand_mask(benchmark::State& state)
   std::free(vec);
 }
 
+// Benchmarks performance of hashing to a ball routine
+template<const uint32_t τ>
+void
+sample_in_ball(benchmark::State& state)
+{
+  constexpr size_t slen = 32;
+  constexpr size_t plen = ntt::N * sizeof(ff::ff_t);
+
+  uint8_t* seed = static_cast<uint8_t*>(std::malloc(slen));
+  ff::ff_t* poly = static_cast<ff::ff_t*>(std::malloc(plen));
+
+  dilithium_utils::random_data<uint8_t>(seed, slen);
+
+  for (auto _ : state) {
+    dilithium_utils::sample_in_ball<τ>(seed, poly);
+
+    benchmark::DoNotOptimize(seed);
+    benchmark::DoNotOptimize(poly);
+    benchmark::ClobberMemory();
+  }
+
+  std::free(seed);
+  std::free(poly);
+}
+
 }

--- a/include/bench_sampling.hpp
+++ b/include/bench_sampling.hpp
@@ -61,4 +61,33 @@ uniform_sampling_eta(benchmark::State& state)
   std::free(vec);
 }
 
+// Benchmark performance of routine which generates mask vector from 48 -bytes
+// seed and 2 -bytes nonce. Generated vector is column vector and of dimension
+// l x 1 s.t. each cell is a degree-255 polynomial.
+template<const uint32_t γ1, const size_t l>
+void
+expand_mask(benchmark::State& state)
+{
+  constexpr size_t slen = 48;
+  constexpr uint16_t nonce = 0;
+  constexpr size_t vlen = l * ntt::N * sizeof(ff::ff_t);
+
+  uint8_t* seed = static_cast<uint8_t*>(std::malloc(slen));
+  ff::ff_t* vec = static_cast<ff::ff_t*>(std::malloc(vlen));
+
+  dilithium_utils::random_data<uint8_t>(seed, slen);
+
+  for (auto _ : state) {
+    dilithium_utils::expand_mask<γ1, l>(seed, nonce, vec);
+
+    benchmark::DoNotOptimize(seed);
+    benchmark::DoNotOptimize(nonce);
+    benchmark::DoNotOptimize(vec);
+    benchmark::ClobberMemory();
+  }
+
+  std::free(seed);
+  std::free(vec);
+}
+
 }

--- a/include/bench_signing.hpp
+++ b/include/bench_signing.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "dilithium.hpp"
+#include "utils.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark Dilithium PQC suite implementation on CPU, using google-benchmark
+namespace bench_dilithium {
+
+// Benchmark Dilithium signing algorithm's performance with different parameters
+// ( for three different NIST security levels )
+template<const size_t k,
+         const size_t l,
+         const size_t d,
+         const uint32_t η,
+         const uint32_t γ1,
+         const uint32_t γ2,
+         const uint32_t τ,
+         const uint32_t β,
+         const size_t ω>
+void
+sign(benchmark::State& state)
+{
+  constexpr size_t slen = 32;
+  constexpr size_t mlen = 32;
+  constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
+  constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
+  constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();
+
+  uint8_t* seed = static_cast<uint8_t*>(std::malloc(slen));
+  uint8_t* pkey = static_cast<uint8_t*>(std::malloc(pklen));
+  uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
+  uint8_t* sig = static_cast<uint8_t*>(std::malloc(siglen));
+  uint8_t* msg = static_cast<uint8_t*>(std::malloc(mlen));
+
+  dilithium_utils::random_data<uint8_t>(seed, slen);
+  dilithium_utils::random_data<uint8_t>(msg, mlen);
+
+  dilithium::keygen<k, l, d, η>(seed, pkey, skey);
+
+  for (auto _ : state) {
+    dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω, mlen>(skey, msg, sig);
+
+    benchmark::DoNotOptimize(skey);
+    benchmark::DoNotOptimize(msg);
+    benchmark::DoNotOptimize(sig);
+    benchmark::ClobberMemory();
+  }
+
+  state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
+
+  bool flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey, msg, sig);
+
+  std::free(seed);
+  std::free(pkey);
+  std::free(skey);
+  std::free(sig);
+  std::free(msg);
+
+  assert(flg);
+}
+
+}

--- a/include/keygen.hpp
+++ b/include/keygen.hpp
@@ -18,7 +18,7 @@ namespace dilithium {
 // Note, ebw = ceil(log2(2 * η + 1))
 //
 // See section 5.4 of specification for public key and secret key byte length.
-template<const size_t k, const size_t l, const uint32_t η, const size_t d>
+template<const size_t k, const size_t l, const size_t d, const uint32_t η>
 static void
 keygen(
   const uint8_t* const __restrict seed, // 32 -bytes seed

--- a/include/reduction.hpp
+++ b/include/reduction.hpp
@@ -42,6 +42,15 @@ power2round(const ff::ff_t r) requires(check_d(d))
   return std::make_pair(hi, lo);
 }
 
+inline static constexpr bool
+check_α(const uint32_t alpha)
+{
+  constexpr uint32_t a = ((ff::Q - 1) / 88) << 1;
+  constexpr uint32_t b = ((ff::Q - 1) / 32) << 1;
+
+  return (alpha == a) || (alpha == b);
+}
+
 // Given an element of Z_q | q = 2^23 - 2^13 + 1, this routine computes high and
 // low order bits s.t.
 //
@@ -54,7 +63,7 @@ power2round(const ff::ff_t r) requires(check_d(d))
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
 template<const uint32_t alpha>
 inline static std::pair<ff::ff_t, ff::ff_t>
-decompose(const ff::ff_t r)
+decompose(const ff::ff_t r) requires(check_α(alpha))
 {
   constexpr uint32_t t0 = alpha >> 1;
   constexpr uint32_t t1 = ff::Q - 1u;
@@ -83,7 +92,7 @@ decompose(const ff::ff_t r)
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
 template<const uint32_t alpha>
 inline static ff::ff_t
-highbits(const ff::ff_t r)
+highbits(const ff::ff_t r) requires(check_α(alpha))
 {
   const auto s = decompose<alpha>(r);
   return s.first;
@@ -97,7 +106,7 @@ highbits(const ff::ff_t r)
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
 template<const uint32_t alpha>
 inline static ff::ff_t
-lowbits(const ff::ff_t r)
+lowbits(const ff::ff_t r) requires(check_α(alpha))
 {
   const auto s = decompose<alpha>(r);
   return s.second;
@@ -114,7 +123,7 @@ lowbits(const ff::ff_t r)
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
 template<const uint32_t alpha>
 inline static ff::ff_t
-make_hint(const ff::ff_t z, const ff::ff_t r)
+make_hint(const ff::ff_t z, const ff::ff_t r) requires(check_α(alpha))
 {
   const ff::ff_t r1 = highbits<alpha>(r);
   const ff::ff_t v1 = highbits<alpha>(r + z);
@@ -130,7 +139,7 @@ make_hint(const ff::ff_t z, const ff::ff_t r)
 // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
 template<const uint32_t alpha>
 inline static ff::ff_t
-use_hint(const ff::ff_t h, const ff::ff_t r)
+use_hint(const ff::ff_t h, const ff::ff_t r) requires(check_α(alpha))
 {
   constexpr uint32_t m = (ff::Q - 1) / alpha;
   constexpr ff::ff_t t0{ alpha >> 1 };

--- a/include/test_signing.hpp
+++ b/include/test_signing.hpp
@@ -44,7 +44,7 @@ test_signing()
 
   bool flg0 = false, flg1 = false, flg2 = false, flg3 = false;
 
-  dilithium::keygen<k, l, η, d>(seed, pkey0, skey);
+  dilithium::keygen<k, l, d, η>(seed, pkey0, skey);
   dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω, mlen>(skey, msg0, sig0);
 
   std::memcpy(sig1, sig0, siglen);


### PR DESCRIPTION
Benchmarks three main operations of Dilithium PQ DSA

- keygen
- sign
- verify

for different parameter sets, offerring different levels of NIST security. 

Issue following command to benchmark implementation

```bash
make benchmark # ensure that you've google-benchmark installed
```

Result looks like below, when benchmarked on **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**, compiled with clang

```bash
2022-10-26T17:53:41+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 2.46, 2.08, 1.95
--------------------------------------------------------------------------------------------------------------
Benchmark                                                                    Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------
bench_dilithium::ff_add                                                   3.73 ns         3.73 ns    189060934
bench_dilithium::ff_sub                                                   3.71 ns         3.71 ns    188945603
bench_dilithium::ff_neg                                                   1.23 ns         1.23 ns    555361620
bench_dilithium::ff_mul                                                   5.93 ns         5.93 ns    116118972
bench_dilithium::ff_inv                                                    107 ns          107 ns      8855285
bench_dilithium::ff_div                                                   65.6 ns         65.6 ns     11746937
bench_dilithium::ff_exp                                                    320 ns          320 ns      2121051
bench_dilithium::ntt                                                      4643 ns         4641 ns       150307
bench_dilithium::intt                                                     4382 ns         4380 ns       160390
bench_dilithium::power2round                                              2.35 ns         2.35 ns    294676046
bench_dilithium::decompose<190464>                                        8.34 ns         8.33 ns     83620031
bench_dilithium::make_hint<190464>                                        13.6 ns         13.6 ns     50562325
bench_dilithium::use_hint<190464>                                         7.97 ns         7.97 ns     85964460
bench_dilithium::decompose<523776>                                        8.74 ns         8.74 ns     78885683
bench_dilithium::make_hint<523776>                                        14.5 ns         14.5 ns     47558225
bench_dilithium::use_hint<523776>                                         8.37 ns         8.37 ns     81638365
bench_dilithium::expand_a<4, 4>                                          52790 ns        52761 ns        12994
bench_dilithium::expand_a<6, 5>                                          96511 ns        96455 ns         7161
bench_dilithium::expand_a<8, 7>                                         177876 ns       177748 ns         3910
bench_dilithium::uniform_sampling_eta<2, 4>                               6523 ns         6522 ns        93941
bench_dilithium::uniform_sampling_eta<2, 8>                              14117 ns        14110 ns        49103
bench_dilithium::uniform_sampling_eta<4, 6>                              16099 ns        16097 ns        42183
bench_dilithium::expand_mask<1u << 17, 4>                                30363 ns        30343 ns        22993
bench_dilithium::expand_mask<1u << 19, 5>                                41157 ns        41141 ns        16972
bench_dilithium::expand_mask<1u << 19, 7>                                58572 ns        58529 ns        11684
bench_dilithium::sample_in_ball<39>                                        634 ns          634 ns      1070877
bench_dilithium::sample_in_ball<49>                                        675 ns          674 ns      1021331
bench_dilithium::sample_in_ball<60>                                        769 ns          769 ns       883270
bench_dilithium::encode<3>                                                 959 ns          959 ns       718487
bench_dilithium::decode<3>                                                1020 ns         1019 ns       681199
bench_dilithium::encode<4>                                                 831 ns          830 ns       828108
bench_dilithium::decode<4>                                                 836 ns          836 ns       823636
bench_dilithium::encode<6>                                                1759 ns         1758 ns       396266
bench_dilithium::decode<6>                                                1826 ns         1826 ns       375978
bench_dilithium::encode<10>                                               2793 ns         2792 ns       248901
bench_dilithium::decode<10>                                               3120 ns         3118 ns       222982
bench_dilithium::encode<13>                                               4333 ns         4330 ns       161577
bench_dilithium::decode<13>                                               4702 ns         4700 ns       150328
bench_dilithium::encode<18>                                               4990 ns         4988 ns       135106
bench_dilithium::decode<18>                                               5810 ns         5804 ns       119252
bench_dilithium::encode<20>                                               5524 ns         5522 ns       124277
bench_dilithium::decode<20>                                               6450 ns         6447 ns       107012
bench_dilithium::encode_hint_bits<4, 80>                                  1542 ns         1542 ns       443187
bench_dilithium::decode_hint_bits<4, 80>                                   102 ns          102 ns      6723206
bench_dilithium::encode_hint_bits<6, 55>                                  2657 ns         2656 ns       261879
bench_dilithium::decode_hint_bits<6, 55>                                   108 ns          108 ns      6349725
bench_dilithium::encode_hint_bits<8, 75>                                  3465 ns         3464 ns       197503
bench_dilithium::decode_hint_bits<8, 75>                                   141 ns          141 ns      4909834
bench_dilithium::keygen<4, 4, 13, 2>                                    155131 ns       155072 ns         4485 items_per_second=6.4486k/s
bench_dilithium::sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>         861753 ns       861503 ns         1308 items_per_second=1.16076k/s
bench_dilithium::verify<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>       184430 ns       184364 ns         3740 items_per_second=5.42404k/s
bench_dilithium::keygen<6, 5, 13, 4>                                    251970 ns       251917 ns         2743 items_per_second=3.96956k/s
bench_dilithium::sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>       972601 ns       972197 ns         1431 items_per_second=1028.6/s
bench_dilithium::verify<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>     278530 ns       278403 ns         2513 items_per_second=3.59192k/s
bench_dilithium::keygen<8, 7, 13, 2>                                    384715 ns       384551 ns         1813 items_per_second=2.60044k/s
bench_dilithium::sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>      2041577 ns      2040950 ns          403 items_per_second=489.968/s
bench_dilithium::verify<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>     430850 ns       430770 ns         1610 items_per_second=2.32142k/s
```