### PR TITLE
Update `sha3` Dependency

### DIFF
--- a/include/bench_signing.hpp
+++ b/include/bench_signing.hpp
@@ -37,7 +37,7 @@ sign(benchmark::State& state)
   dilithium::keygen<k, l, d, η>(seed, pkey, skey);
 
   for (auto _ : state) {
-    dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω, mlen>(skey, msg, sig);
+    dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω>(skey, msg, mlen, sig);
 
     benchmark::DoNotOptimize(skey);
     benchmark::DoNotOptimize(msg);
@@ -47,7 +47,7 @@ sign(benchmark::State& state)
 
   state.SetItemsProcessed(static_cast<int64_t>(state.iterations()));
 
-  bool flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey, msg, sig);
+  bool flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey, msg, mlen, sig);
 
   std::free(seed);
   std::free(pkey);

--- a/include/bench_verification.hpp
+++ b/include/bench_verification.hpp
@@ -35,11 +35,11 @@ verify(benchmark::State& state)
   dilithium_utils::random_data<uint8_t>(msg, mlen);
 
   dilithium::keygen<k, l, d, η>(seed, pkey, skey);
-  dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω, mlen>(skey, msg, sig);
+  dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω>(skey, msg, mlen, sig);
 
   for (auto _ : state) {
     bool flg = false;
-    flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey, msg, sig);
+    flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey, msg, mlen, sig);
     assert(flg);
 
     benchmark::DoNotOptimize(flg);

--- a/include/test_signing.hpp
+++ b/include/test_signing.hpp
@@ -21,16 +21,17 @@ template<const size_t k,
          const uint32_t γ2,
          const uint32_t τ,
          const uint32_t β,
-         const size_t ω,
-         const size_t mlen>
+         const size_t ω>
 static void
 test_signing()
 {
+  constexpr size_t slen = 32;
+  constexpr size_t mlen = 33;
   constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
   constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
   constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();
 
-  uint8_t* seed = static_cast<uint8_t*>(std::malloc(32));
+  uint8_t* seed = static_cast<uint8_t*>(std::malloc(slen));
   uint8_t* pkey0 = static_cast<uint8_t*>(std::malloc(pklen));
   uint8_t* pkey1 = static_cast<uint8_t*>(std::malloc(pklen));
   uint8_t* skey = static_cast<uint8_t*>(std::malloc(sklen));
@@ -39,13 +40,13 @@ test_signing()
   uint8_t* msg0 = static_cast<uint8_t*>(std::malloc(mlen));
   uint8_t* msg1 = static_cast<uint8_t*>(std::malloc(mlen));
 
-  dilithium_utils::random_data<uint8_t>(seed, 32);
+  dilithium_utils::random_data<uint8_t>(seed, slen);
   dilithium_utils::random_data<uint8_t>(msg0, mlen);
 
   bool flg0 = false, flg1 = false, flg2 = false, flg3 = false;
 
   dilithium::keygen<k, l, d, η>(seed, pkey0, skey);
-  dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω, mlen>(skey, msg0, sig0);
+  dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω>(skey, msg0, mlen, sig0);
 
   std::memcpy(sig1, sig0, siglen);
   std::memcpy(pkey1, pkey0, pklen);
@@ -55,10 +56,10 @@ test_signing()
   dilithium_utils::random_bit_flip(pkey1, pklen);
   dilithium_utils::random_bit_flip(msg1, mlen);
 
-  flg0 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey0, msg0, sig0);
-  flg1 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey0, msg0, sig1);
-  flg2 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey1, msg0, sig0);
-  flg3 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω, mlen>(pkey0, msg1, sig0);
+  flg0 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey0, msg0, mlen, sig0);
+  flg1 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey0, msg0, mlen, sig1);
+  flg2 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey1, msg0, mlen, sig0);
+  flg3 = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pkey0, msg1, mlen, sig0);
 
   std::free(pkey0);
   std::free(pkey1);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -42,9 +42,9 @@ main()
     using namespace test_dilithium;
 
     // NIST security level 2, 3, 5 ( in order )
-    test_signing<4, 4, 13, 2, 1u << 17, (ff::Q - 1) / 88, 39, 78, 80, 33>();
-    test_signing<6, 5, 13, 4, 1u << 19, (ff::Q - 1) / 32, 49, 196, 55, 33>();
-    test_signing<8, 7, 13, 2, 1u << 19, (ff::Q - 1) / 32, 60, 120, 75, 33>();
+    test_signing<4, 4, 13, 2, 1u << 17, (ff::Q - 1) / 88, 39, 78, 80>();
+    test_signing<6, 5, 13, 4, 1u << 19, (ff::Q - 1) / 32, 49, 196, 55>();
+    test_signing<8, 7, 13, 2, 1u << 19, (ff::Q - 1) / 32, 60, 120, 75>();
 
     std::cout
       << "[test] Dilithium-{2, 3, 5} KeyGen -> Signing -> Verification\n";


### PR DESCRIPTION
- Update `sha3` dependency to latest commit, which supports incremental hashing ( for SHAKE{128, 256} )
- This removes the need for knowing message ( to be signed by Dilithium ) length  at compile-time

> **Note**
> This work benefits from https://github.com/itzmeanjan/sha3/pull/12.

Now Dilithium API usage example looks like

```cpp
#include "dilithium.hpp"
#include <cassert>
#include <iostream>

int
main()
{
  // Dilithium2 Parameters
  //
  // See table 2 of Dilithium specification
  // https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
  // for all parameters
  constexpr size_t k = 4;
  constexpr size_t l = 4;
  constexpr uint32_t η = 2;
  constexpr size_t d = 13;
  constexpr uint32_t γ1 = 1u << 17;
  constexpr uint32_t γ2 = (ff::Q - 1) / 88;
  constexpr uint32_t τ = 39;
  constexpr uint32_t β = τ * η;
  constexpr size_t ω = 80;

  constexpr size_t slen = 32; // seed length
  constexpr size_t mlen = 32; // message length

  constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
  constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
  constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();

  uint8_t seed[slen]{};
  uint8_t msg[mlen]{};
  uint8_t pubkey[pklen]{};
  uint8_t seckey[sklen]{};
  uint8_t sig[siglen]{};

  dilithium_utils::random_data<uint8_t>(seed, slen);
  dilithium_utils::random_data<uint8_t>(msg, mlen);

  bool flg = false;

  dilithium::keygen<k, l, d, η>(seed, pubkey, seckey);
  dilithium::sign<k, l, d, η, γ1, γ2, τ, β, ω>(seckey, msg, mlen, sig);
  flg = dilithium::verify<k, l, d, γ1, γ2, τ, β, ω>(pubkey, msg, mlen, sig);

  {
    using namespace dilithium_utils;

    std::cout << "pubkey : " << to_hex(pubkey, pklen) << "\n";
    std::cout << "seckey : " << to_hex(seckey, sklen) << "\n";
    std::cout << "message : " << to_hex(msg, sizeof(msg)) << "\n";
    std::cout << "signature : " << to_hex(sig, siglen) << "\n";
    std::cout << "verified : " << std::boolalpha << flg << "\n";
  }

  assert(flg);

  return EXIT_SUCCESS;
}
```