### PR TITLE
Update Dilithium KeyGen, Signing & Verification to Latest Specification

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -26,9 +26,9 @@ BENCHMARK(bench_dilithium::use_hint<523776>);
 BENCHMARK(bench_dilithium::expand_a<4, 4>);
 BENCHMARK(bench_dilithium::expand_a<6, 5>);
 BENCHMARK(bench_dilithium::expand_a<8, 7>);
-BENCHMARK(bench_dilithium::uniform_sampling_eta<2, 4>);
-BENCHMARK(bench_dilithium::uniform_sampling_eta<2, 8>);
-BENCHMARK(bench_dilithium::uniform_sampling_eta<4, 6>);
+BENCHMARK(bench_dilithium::expand_s<2, 4>);
+BENCHMARK(bench_dilithium::expand_s<2, 8>);
+BENCHMARK(bench_dilithium::expand_s<4, 6>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 17, 4>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 19, 5>);
 BENCHMARK(bench_dilithium::expand_mask<1u << 19, 7>);
@@ -61,15 +61,17 @@ BENCHMARK(bench_dilithium::encode_hint_bits<8, 75>);
 BENCHMARK(bench_dilithium::decode_hint_bits<8, 75>);
 
 // register for benchmarking Dilithium Key Generation, Signing & Verification
-BENCHMARK(bench_dilithium::keygen<4, 4, 13, 2>); // NIST security level 2
-BENCHMARK(bench_dilithium::sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>);
-BENCHMARK(bench_dilithium::verify<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>);
-BENCHMARK(bench_dilithium::keygen<6, 5, 13, 4>); // NIST security level 3
-BENCHMARK(bench_dilithium::sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>);
-BENCHMARK(bench_dilithium::verify<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>);
-BENCHMARK(bench_dilithium::keygen<8, 7, 13, 2>); // NIST security level 5
-BENCHMARK(bench_dilithium::sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>);
-BENCHMARK(bench_dilithium::verify<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>);
+using namespace bench_dilithium;
+
+BENCHMARK(keygen<4, 4, 13, 2>)->Arg(32);
+BENCHMARK(sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>)->Arg(32);
+BENCHMARK(verify<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>)->Arg(32);
+BENCHMARK(keygen<6, 5, 13, 4>)->Arg(32);
+BENCHMARK(sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>)->Arg(32);
+BENCHMARK(verify<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>)->Arg(32);
+BENCHMARK(keygen<8, 7, 13, 2>)->Arg(32);
+BENCHMARK(sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>)->Arg(32);
+BENCHMARK(verify<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>)->Arg(32);
 
 // benchmark runner main routine
 BENCHMARK_MAIN();

--- a/include/bench_sampling.hpp
+++ b/include/bench_sampling.hpp
@@ -35,12 +35,12 @@ expand_a(benchmark::State& state)
 
 // Benchmark uniform sampling of k degree-255 polynomials s.t. each coefficient
 // ∈ [-η, η]. Coefficients are sampled from a XOF ( read SHAKE256 ), while it's
-// seeded with 32 -bytes randomness and 2 -bytes nonce.
+// seeded with 64 -bytes randomness and 2 -bytes nonce.
 template<const uint32_t η, const size_t k>
 void
-uniform_sampling_eta(benchmark::State& state)
+expand_s(benchmark::State& state)
 {
-  constexpr size_t slen = 32;
+  constexpr size_t slen = 64;
   constexpr size_t nonce = 0;
   constexpr size_t vlen = k * ntt::N * sizeof(ff::ff_t);
 
@@ -50,7 +50,7 @@ uniform_sampling_eta(benchmark::State& state)
   dilithium_utils::random_data<uint8_t>(seed, slen);
 
   for (auto _ : state) {
-    dilithium_utils::uniform_sample_eta<η, k, nonce>(seed, vec);
+    dilithium_utils::expand_s<η, k, nonce>(seed, vec);
 
     benchmark::DoNotOptimize(seed);
     benchmark::DoNotOptimize(vec);
@@ -68,7 +68,7 @@ template<const uint32_t γ1, const size_t l>
 void
 expand_mask(benchmark::State& state)
 {
-  constexpr size_t slen = 48;
+  constexpr size_t slen = 64;
   constexpr uint16_t nonce = 0;
   constexpr size_t vlen = l * ntt::N * sizeof(ff::ff_t);
 

--- a/include/bench_signing.hpp
+++ b/include/bench_signing.hpp
@@ -19,8 +19,8 @@ template<const size_t k,
 void
 sign(benchmark::State& state)
 {
+  const size_t mlen = state.range(0);
   constexpr size_t slen = 32;
-  constexpr size_t mlen = 32;
   constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
   constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
   constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();

--- a/include/bench_verification.hpp
+++ b/include/bench_verification.hpp
@@ -19,8 +19,8 @@ template<const size_t k,
 void
 verify(benchmark::State& state)
 {
+  const size_t mlen = state.range(0);
   constexpr size_t slen = 32;
-  constexpr size_t mlen = 32;
   constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
   constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
   constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();

--- a/include/bit_packing.hpp
+++ b/include/bit_packing.hpp
@@ -18,9 +18,8 @@ check_sbw(const size_t sbw)
 // of them ) coefficient ∈ [0, 2^sbw), this routine serializes the polynomial to
 // a byte array of length 32 * sbw -bytes
 //
-// See section 5.2 ( which describes bit packing ) of Dilithium specification,
-// as submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See section 5.2 ( which describes bit packing ) of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t sbw>
 static void
 encode(const ff::ff_t* const __restrict poly,
@@ -46,6 +45,10 @@ encode(const ff::ff_t* const __restrict poly,
 // Given a byte array of length 32 * sbw -bytes, this routine attempts to
 // extract out 256 coefficients of degree-255 polynomial s.t. significant
 // portion of each coefficient ∈ [0, 2^sbw)
+//
+// This is just the opposite of above `encode` routine. You may want to see
+// Dilithium specification's section 5.2
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t sbw>
 static void
 decode(const uint8_t* const __restrict arr,

--- a/include/bit_packing.hpp
+++ b/include/bit_packing.hpp
@@ -71,9 +71,9 @@ decode(const uint8_t* const __restrict arr,
 }
 
 // Given a vector of hint bits ( of dimension k x 1 ), this routine encodes hint
-// bits into (ω + k) -bytes, following the description in section 5.4 of
-// Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// bits into (ω + k) -bytes, following the description in section 5.4 ( see
+// point `Signature` on page 21 ) of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k, const size_t ω>
 static void
 encode_hint_bits(const ff::ff_t* const __restrict h,
@@ -107,7 +107,8 @@ encode_hint_bits(const ff::ff_t* const __restrict h,
 // many hint bits are set.
 //
 // Returns boolean result denoting status of decoding of byte serialized hint
-// bits. Say return value is true, it denotes that decoding has failed.
+// bits. For example, say return value is true, it denotes that decoding has
+// failed.
 template<const size_t k, const size_t ω>
 static bool
 decode_hint_bits(const uint8_t* const __restrict arr,

--- a/include/keygen.hpp
+++ b/include/keygen.hpp
@@ -7,13 +7,13 @@ namespace dilithium {
 
 // Given 32 -bytes seed, this routine generates Dilithium public key and secret
 // key pair, using deterministic key generation algorithm, as described in
-// figure 4 of Dilithium specification, as submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// figure 4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 //
 // See table 2 of specification for allowed parameters.
 //
 // Generated public key is of (32 + k * 320) -bytes.
-// Generated secret key is of (112 + 32 * (k * ebw + l * ebw + k * d)) -bytes
+// Generated secret key is of (96 + 32 * (k * ebw + l * ebw + k * d)) -bytes
 //
 // Note, ebw = ceil(log2(2 * η + 1))
 //
@@ -23,33 +23,33 @@ static void
 keygen(
   const uint8_t* const __restrict seed, // 32 -bytes seed
   uint8_t* const __restrict pubkey,     // (32 + k * 320) -bytes
-  uint8_t* const __restrict seckey // (112 + 32 * (ebw*(k + l) + k*d)) -bytes
+  uint8_t* const __restrict seckey // (96 + 32 * (ebw*(k + l) + k*d)) -bytes
   ) requires(dilithium_utils::check_η(η) && dilithium_utils::check_d(d))
 {
-  uint8_t seed_hash[32 * 3]{};
+  uint8_t seed_hash[32 + 64 + 32]{};
 
-  shake256::shake256 hasher{};
-  hasher.hash(seed, 32);
-  hasher.read(seed_hash, sizeof(seed_hash));
+  shake256::shake256 hasher0{};
+  hasher0.hash(seed, 32);
+  hasher0.read(seed_hash, sizeof(seed_hash));
 
   const uint8_t* rho = seed_hash + 0;
-  const uint8_t* sigma = seed_hash + 32;
-  const uint8_t* key = seed_hash + 64;
-
-  ff::ff_t s1[l * ntt::N]{};
-  ff::ff_t s1_prime[l * ntt::N]{};
-
-  dilithium_utils::uniform_sample_eta<η, l, 0>(sigma, s1);
-  std::memcpy(s1_prime, s1, sizeof(s1));
-  dilithium_utils::polyvec_ntt<l>(s1_prime);
-
-  ff::ff_t s2[k * ntt::N]{};
-
-  dilithium_utils::uniform_sample_eta<η, k, l>(sigma, s2);
+  const uint8_t* rho_prime = rho + 32;
+  const uint8_t* key = rho_prime + 64;
 
   ff::ff_t A[k * l * ntt::N]{};
 
   dilithium_utils::expand_a<k, l>(rho, A);
+
+  ff::ff_t s1[l * ntt::N]{};
+  ff::ff_t s2[k * ntt::N]{};
+
+  dilithium_utils::expand_s<η, l, 0>(rho_prime, s1);
+  dilithium_utils::expand_s<η, k, l>(rho_prime, s2);
+
+  ff::ff_t s1_prime[l * ntt::N]{};
+
+  std::memcpy(s1_prime, s1, sizeof(s1));
+  dilithium_utils::polyvec_ntt<l>(s1_prime);
 
   ff::ff_t t[k * ntt::N]{};
 
@@ -64,19 +64,19 @@ keygen(
 
   constexpr size_t t1_bw = std::bit_width(ff::Q) - d;
   uint8_t crh_in[32 + k * 32 * t1_bw]{};
-  uint8_t tr[48]{};
+  uint8_t tr[32]{};
 
   std::memcpy(crh_in, rho, 32);
   dilithium_utils::polyvec_encode<k, t1_bw>(t1, crh_in + 32);
 
-  shake256::shake256 crh{};
-  crh.hash(crh_in, sizeof(crh_in));
-  crh.read(tr, sizeof(tr));
+  shake256::shake256 hasher1{};
+  hasher1.hash(crh_in, sizeof(crh_in));
+  hasher1.read(tr, sizeof(tr));
 
   std::memcpy(pubkey, crh_in, sizeof(crh_in));
   std::memcpy(seckey, rho, 32);
   std::memcpy(seckey + 32, key, 32);
-  std::memcpy(seckey + 64, tr, 48);
+  std::memcpy(seckey + 64, tr, 32);
 
   dilithium_utils::polyvec_sub_from_x<l, η>(s1);
   dilithium_utils::polyvec_sub_from_x<k, η>(s2);
@@ -85,13 +85,13 @@ keygen(
   constexpr size_t s1_len = l * eta_bw * 32;
   constexpr size_t s2_len = k * eta_bw * 32;
 
-  dilithium_utils::polyvec_encode<l, eta_bw>(s1, seckey + 112);
-  dilithium_utils::polyvec_encode<k, eta_bw>(s2, seckey + 112 + s1_len);
+  dilithium_utils::polyvec_encode<l, eta_bw>(s1, seckey + 96);
+  dilithium_utils::polyvec_encode<k, eta_bw>(s2, seckey + 96 + s1_len);
 
   constexpr uint32_t t0_rng = 1u << (d - 1);
 
   dilithium_utils::polyvec_sub_from_x<k, t0_rng>(t0);
-  dilithium_utils::polyvec_encode<k, d>(t0, seckey + 112 + s1_len + s2_len);
+  dilithium_utils::polyvec_encode<k, d>(t0, seckey + 96 + s1_len + s2_len);
 }
 
 }

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -75,7 +75,7 @@ poly_lowbits(const ff::ff_t* const __restrict src,
 // Computes infinity norm of a degree-255 polynomial
 //
 // See point `Sizes of elements` in section 2.1 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 inline static ff::ff_t
 poly_infinity_norm(const ff::ff_t* const __restrict poly)
 {

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -205,7 +205,7 @@ polyvec_mul_poly(const ff::ff_t* const __restrict poly,
 // polynomials
 //
 // See point `Sizes of elements` in section 2.1 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k>
 inline static ff::ff_t
 polyvec_infinity_norm(const ff::ff_t* const __restrict vec)

--- a/include/reduction.hpp
+++ b/include/reduction.hpp
@@ -57,9 +57,8 @@ check_α(const uint32_t alpha)
 //
 // If r1 = (q - 1)/ α then r1 = 0; r0 = r0 - 1
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha>
 inline static std::pair<ff::ff_t, ff::ff_t>
 decompose(const ff::ff_t r) requires(check_α(alpha))
@@ -86,9 +85,8 @@ decompose(const ff::ff_t r) requires(check_α(alpha))
 // Given an element ∈ Z_q, this routine uses decompose routine ( defined above )
 // to extract out high order bits of r.
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha>
 inline static ff::ff_t
 highbits(const ff::ff_t r) requires(check_α(alpha))
@@ -100,9 +98,8 @@ highbits(const ff::ff_t r) requires(check_α(alpha))
 // Given an element ∈ Z_q, this routine uses decompose routine ( defined above )
 // to extract out low order bits of r.
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha>
 inline static ff::ff_t
 lowbits(const ff::ff_t r) requires(check_α(alpha))
@@ -117,9 +114,8 @@ lowbits(const ff::ff_t r) requires(check_α(alpha))
 // This hint is essentially the “carry” caused by z in the addition.
 // Note, z is small.
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha>
 inline static ff::ff_t
 make_hint(const ff::ff_t z, const ff::ff_t r) requires(check_α(alpha))
@@ -133,9 +129,8 @@ make_hint(const ff::ff_t z, const ff::ff_t r) requires(check_α(alpha))
 // 1 -bit hint ( read h ) is used to recover higher order bits of r + z s.t.
 // hint bit was computed using make_hint routine ( defined above ).
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha>
 inline static ff::ff_t
 use_hint(const ff::ff_t h, const ff::ff_t r) requires(check_α(alpha))

--- a/include/reduction.hpp
+++ b/include/reduction.hpp
@@ -20,9 +20,8 @@ check_d(const size_t d)
 //
 // so that public key can be compressed.
 //
-// See definition of this routine in figure 3 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See definition of this routine in figure 3 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 //
 // This implementation collects some ideas from
 // https://github.com/pq-crystals/dilithium/blob/3e9b9f1/ref/rounding.c#L5-L23

--- a/include/signing.hpp
+++ b/include/signing.hpp
@@ -6,16 +6,15 @@
 namespace dilithium {
 
 // Given a Dilithium secret key and message, this routine uses Dilithium
-// signature generation algorithm for computing deterministic signature over
-// input messsage, using provided parameters.
+// signing algorithm for computing deterministic signature for input messsage,
+// using provided parameters.
 //
-// Signing algorithm is described in figure 4 of Dilithium specification, as
-// submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// Signing algorithm is described in figure 4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 //
 // For Dilithium parameters, see table 2 of specification.
 //
-// Generated signature is of ((32 * l * gamma1_bw) + (ω + k) + 32) -bytes
+// Generated signature is of (32 + (32 * l * gamma1_bw) + (ω + k)) -bytes
 //
 // s.t. gamma1_bw = floor(log2(γ1)) + 1
 //
@@ -48,7 +47,7 @@ sign(const uint8_t* const __restrict seckey,
   constexpr size_t secoff0 = 0;
   constexpr size_t secoff1 = secoff0 + 32;
   constexpr size_t secoff2 = secoff1 + 32;
-  constexpr size_t secoff3 = secoff2 + 48;
+  constexpr size_t secoff3 = secoff2 + 32;
   constexpr size_t secoff4 = secoff3 + s1_len;
   constexpr size_t secoff5 = secoff4 + s2_len;
 
@@ -60,23 +59,23 @@ sign(const uint8_t* const __restrict seckey,
 
   dilithium_utils::expand_a<k, l>(rho, A);
 
-  uint8_t mu[48]{};
+  uint8_t mu[64]{};
 
-  shake256::shake256<true> crh0{};
-  crh0.absorb(tr, 48);
-  crh0.absorb(msg, mlen);
-  crh0.finalize();
-  crh0.read(mu, sizeof(mu));
+  shake256::shake256<true> hasher0{};
+  hasher0.absorb(tr, 32);
+  hasher0.absorb(msg, mlen);
+  hasher0.finalize();
+  hasher0.read(mu, sizeof(mu));
 
-  uint8_t crh_in[32 + 48]{};
-  uint8_t rho_prime[48]{};
+  uint8_t crh_in[32 + 64]{};
+  uint8_t rho_prime[64]{};
 
   std::memcpy(crh_in + 0, key, 32);
   std::memcpy(crh_in + 32, mu, sizeof(mu));
 
-  shake256::shake256 crh1{};
-  crh1.hash(crh_in, sizeof(crh_in));
-  crh1.read(rho_prime, sizeof(rho_prime));
+  shake256::shake256 hasher1{};
+  hasher1.hash(crh_in, sizeof(crh_in));
+  hasher1.read(rho_prime, sizeof(rho_prime));
 
   ff::ff_t s1[l * ntt::N]{};
   ff::ff_t s2[k * ntt::N]{};
@@ -95,7 +94,7 @@ sign(const uint8_t* const __restrict seckey,
   dilithium_utils::polyvec_ntt<k>(t0);
 
   bool has_signed = false;
-  size_t nonce = 0;
+  uint16_t kappa = 0;
 
   ff::ff_t z[l * ntt::N]{};
   ff::ff_t h[k * ntt::N]{};
@@ -106,28 +105,30 @@ sign(const uint8_t* const __restrict seckey,
     ff::ff_t y_prime[l * ntt::N]{};
     ff::ff_t w[k * ntt::N]{};
 
-    dilithium_utils::expand_mask<γ1, l>(rho_prime, nonce, y);
+    dilithium_utils::expand_mask<γ1, l>(rho_prime, kappa, y);
+
     std::memcpy(y_prime, y, sizeof(y));
 
     dilithium_utils::polyvec_ntt<l>(y_prime);
     dilithium_utils::matrix_multiply<k, l, l, 1>(A, y_prime, w);
     dilithium_utils::polyvec_intt<k>(w);
 
-    constexpr uint32_t m = (ff::Q - 1u) / (γ2 << 1);
+    constexpr uint32_t α = γ2 << 1;
+    constexpr uint32_t m = (ff::Q - 1u) / α;
     constexpr size_t w1bw = std::bit_width(m - 1u);
 
     ff::ff_t w1[k * ntt::N]{};
-    uint8_t hash_in[48 + (k * w1bw * 32)]{};
+    uint8_t hash_in[64 + (k * w1bw * 32)]{};
     ff::ff_t c[ntt::N]{};
 
-    dilithium_utils::polyvec_highbits<k, γ2 << 1>(w, w1);
+    dilithium_utils::polyvec_highbits<k, α>(w, w1);
 
-    std::memcpy(hash_in, mu, 48);
-    dilithium_utils::polyvec_encode<k, w1bw>(w1, hash_in + 48);
+    std::memcpy(hash_in, mu, 64);
+    dilithium_utils::polyvec_encode<k, w1bw>(w1, hash_in + 64);
 
-    shake256::shake256 hasher{};
-    hasher.hash(hash_in, sizeof(hash_in));
-    hasher.read(hash_out, sizeof(hash_out));
+    shake256::shake256 hasher2{};
+    hasher2.hash(hash_in, sizeof(hash_in));
+    hasher2.read(hash_out, sizeof(hash_out));
 
     dilithium_utils::sample_in_ball<τ>(hash_out, c);
     ntt::ntt(c);
@@ -143,7 +144,7 @@ sign(const uint8_t* const __restrict seckey,
     dilithium_utils::polyvec_intt<k>(r1);
     dilithium_utils::polyvec_neg<k>(r1);
     dilithium_utils::polyvec_add_to<k>(w, r1);
-    dilithium_utils::polyvec_lowbits<k, γ2 << 1>(r1, r0);
+    dilithium_utils::polyvec_lowbits<k, α>(r1, r0);
 
     const ff::ff_t z_norm = dilithium_utils::polyvec_infinity_norm<l>(z);
     const ff::ff_t r0_norm = dilithium_utils::polyvec_infinity_norm<k>(r0);
@@ -165,7 +166,7 @@ sign(const uint8_t* const __restrict seckey,
     std::memcpy(h1, h0, sizeof(h0));
     dilithium_utils::polyvec_neg<k>(h0);
     dilithium_utils::polyvec_add_to<k>(h1, r1);
-    dilithium_utils::polyvec_make_hint<k, γ2 << 1>(h0, r1, h);
+    dilithium_utils::polyvec_make_hint<k, α>(h0, r1, h);
 
     const ff::ff_t ct0_norm = dilithium_utils::polyvec_infinity_norm<k>(h1);
     const size_t count_1 = dilithium_utils::polyvec_count_1s<k>(h);
@@ -177,18 +178,18 @@ sign(const uint8_t* const __restrict seckey,
     const bool flg5 = flg3 | flg4;
 
     has_signed = has_signed & !flg5;
-    nonce += l;
+    kappa += static_cast<uint16_t>(l);
   }
 
   constexpr size_t gamma1_bw = std::bit_width(γ1);
   constexpr size_t sigoff0 = 0;
-  constexpr size_t sigoff1 = sigoff0 + (32 * l * gamma1_bw);
-  constexpr size_t sigoff2 = sigoff1 + (ω + k);
+  constexpr size_t sigoff1 = sigoff0 + 32;
+  constexpr size_t sigoff2 = sigoff1 + (32 * l * gamma1_bw);
 
+  std::memcpy(sig + sigoff0, hash_out, sizeof(hash_out));
   dilithium_utils::polyvec_sub_from_x<l, γ1>(z);
-  dilithium_utils::polyvec_encode<l, gamma1_bw>(z, sig + sigoff0);
-  dilithium_utils::encode_hint_bits<k, ω>(h, sig + sigoff1);
-  std::memcpy(sig + sigoff2, hash_out, 32);
+  dilithium_utils::polyvec_encode<l, gamma1_bw>(z, sig + sigoff1);
+  dilithium_utils::encode_hint_bits<k, ω>(h, sig + sigoff2);
 }
 
 }

--- a/include/test_reduction.hpp
+++ b/include/test_reduction.hpp
@@ -31,7 +31,7 @@ test_power2round()
 // z both, but they can still recover high order bits of r + z
 //
 // Read section 2.4 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const uint32_t alpha, const uint32_t z, const size_t rounds = 65536ul>
 static void
 test_decompose()

--- a/include/test_signing.hpp
+++ b/include/test_signing.hpp
@@ -6,8 +6,8 @@
 namespace test_dilithium {
 
 // Test functional correctness of Dilithium signature scheme by generating
-// random key pair, signing random message ( of mlen -bytes ) and finally attempting to
-// verify using respective public key.
+// random key pair, signing random message ( of mlen -bytes ) and finally
+// attempting to verify using respective public key.
 //
 // In case when signature is not mutated ( the good case ), it should be able to
 // verify successfully, while in the case when random bit flip is introduced

--- a/include/test_signing.hpp
+++ b/include/test_signing.hpp
@@ -6,7 +6,7 @@
 namespace test_dilithium {
 
 // Test functional correctness of Dilithium signature scheme by generating
-// random key pair, signing random message bytes and finally attempting to
+// random key pair, signing random message ( of mlen -bytes ) and finally attempting to
 // verify using respective public key.
 //
 // In case when signature is not mutated ( the good case ), it should be able to
@@ -23,10 +23,9 @@ template<const size_t k,
          const uint32_t β,
          const size_t ω>
 static void
-test_signing()
+test_signing(const size_t mlen)
 {
   constexpr size_t slen = 32;
-  constexpr size_t mlen = 33;
   constexpr size_t pklen = dilithium_utils::pubkey_length<k, d>();
   constexpr size_t sklen = dilithium_utils::seckey_length<k, l, η, d>();
   constexpr size_t siglen = dilithium_utils::signature_length<k, l, γ1, ω>();

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -23,8 +23,8 @@ random_data(T* const data, const size_t len) requires(std::is_unsigned_v<T>)
 // Compile-time compute how many bytes to reserve for storing serialized
 // Dilithium public key, for given parameter set
 //
-// See table 2 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See table 2 and section 5.4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k, const size_t d>
 inline static constexpr size_t
 pubkey_length() requires(check_d(d))
@@ -37,8 +37,8 @@ pubkey_length() requires(check_d(d))
 // Compile-time compute how many bytes to reserve for storing serialized
 // Dilithium secret key, for given parameter set
 //
-// See table 2 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See table 2 and section 5.4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k, const size_t l, const uint32_t η, const size_t d>
 inline static constexpr size_t
 seckey_length() requires(check_d(d))
@@ -51,14 +51,14 @@ seckey_length() requires(check_d(d))
 // Compile-time compute how many bytes to reserve for storing serialized
 // Dilithium signature, for specified parameter set
 //
-// See table 2 of Dilithium specification
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// See table 2 and section 5.4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k, const size_t l, const uint32_t γ1, const size_t ω>
 inline static constexpr size_t
 signature_length()
 {
   constexpr size_t gamma1_bw = std::bit_width(γ1);
-  constexpr size_t siglen = 32 * l * gamma1_bw + ω + k + 32;
+  constexpr size_t siglen = 32 + (32 * l * gamma1_bw) + (ω + k);
   return siglen;
 }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -44,7 +44,7 @@ inline static constexpr size_t
 seckey_length() requires(check_d(d))
 {
   constexpr size_t eta_bw = std::bit_width(2 * η);
-  constexpr size_t sklen = 32 + 32 + 48 + 32 * (eta_bw * (k + l) + k * d);
+  constexpr size_t sklen = 32 + 32 + 32 + 32 * (eta_bw * (k + l) + k * d);
   return sklen;
 }
 

--- a/include/verification.hpp
+++ b/include/verification.hpp
@@ -6,13 +6,13 @@
 // Dilithium Post-Quantum Digital Signature Algorithm
 namespace dilithium {
 
-// Given a Dilithium public key, message and signature, this routine verifies
-// the correctness of signature, returning boolean result, denoting status of
-// signature verification.
+// Given a Dilithium public key, message bytes and serialized signature, this
+// routine verifies the correctness of signature, returning boolean result,
+// denoting status of signature verification. For example, say it returns true,
+// it means signature has successfully been verified.
 //
-// Verification algorithm is described in figure 4 of Dilithium specification,
-// as submitted to NIST final round call
-// https://csrc.nist.gov/CSRC/media/Projects/post-quantum-cryptography/documents/round-3/submissions/Dilithium-Round3.zip
+// Verification algorithm is described in figure 4 of Dilithium specification
+// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
 template<const size_t k,
          const size_t l,
          const size_t d,
@@ -38,8 +38,8 @@ verify(
 
   constexpr size_t gamma1_bw = std::bit_width(γ1);
   constexpr size_t sigoff0 = 0;
-  constexpr size_t sigoff1 = sigoff0 + (32 * l * gamma1_bw);
-  constexpr size_t sigoff2 = sigoff1 + (ω + k);
+  constexpr size_t sigoff1 = sigoff0 + 32;
+  constexpr size_t sigoff2 = sigoff1 + (32 * l * gamma1_bw);
 
   ff::ff_t A[k * l * ntt::N]{};
   ff::ff_t t1[k * ntt::N]{};
@@ -47,12 +47,12 @@ verify(
   dilithium_utils::expand_a<k, l>(pubkey + puboff0, A);
   dilithium_utils::polyvec_decode<k, t1_bw>(pubkey + puboff1, t1);
 
-  uint8_t crh_in[48]{};
-  uint8_t mu[48]{};
+  uint8_t crh_in[32]{};
+  uint8_t mu[64]{};
 
   shake256::shake256 hasher0{};
   hasher0.hash(pubkey, pklen);
-  hasher0.read(crh_in, 48);
+  hasher0.read(crh_in, sizeof(crh_in));
 
   shake256::shake256<true> hasher1{};
   hasher1.absorb(crh_in, sizeof(crh_in));
@@ -62,15 +62,15 @@ verify(
 
   ff::ff_t c[ntt::N]{};
 
-  dilithium_utils::sample_in_ball<τ>(sig + sigoff2, c);
+  dilithium_utils::sample_in_ball<τ>(sig + sigoff0, c);
   ntt::ntt(c);
 
   ff::ff_t z[l * ntt::N]{};
   ff::ff_t h[k * ntt::N]{};
 
-  dilithium_utils::polyvec_decode<l, gamma1_bw>(sig + sigoff0, z);
+  dilithium_utils::polyvec_decode<l, gamma1_bw>(sig + sigoff1, z);
   dilithium_utils::polyvec_sub_from_x<l, γ1>(z);
-  bool failed = dilithium_utils::decode_hint_bits<k, ω>(sig + sigoff1, h);
+  const bool failed = dilithium_utils::decode_hint_bits<k, ω>(sig + sigoff2, h);
 
   ff::ff_t w0[k * ntt::N]{};
   ff::ff_t w1[k * ntt::N]{};
@@ -90,16 +90,17 @@ verify(
   dilithium_utils::polyvec_add_to<k>(w0, w2);
   dilithium_utils::polyvec_intt<k>(w2);
 
-  dilithium_utils::polyvec_use_hint<k, γ2 << 1>(h, w2, w1);
-
-  constexpr uint32_t m = (ff::Q - 1u) / (γ2 << 1);
+  constexpr uint32_t α = γ2 << 1;
+  constexpr uint32_t m = (ff::Q - 1u) / α;
   constexpr size_t w1bw = std::bit_width(m - 1u);
 
-  uint8_t hash_in[48 + (k * w1bw * 32)]{};
+  dilithium_utils::polyvec_use_hint<k, α>(h, w2, w1);
+
+  uint8_t hash_in[64 + (k * w1bw * 32)]{};
   uint8_t hash_out[32]{};
 
   std::memcpy(hash_in, mu, sizeof(mu));
-  dilithium_utils::polyvec_encode<k, w1bw>(w1, hash_in + 48);
+  dilithium_utils::polyvec_encode<k, w1bw>(w1, hash_in + 64);
 
   shake256::shake256 hasher2{};
   hasher2.hash(hash_in, sizeof(hash_in));
@@ -112,7 +113,7 @@ verify(
   const bool flg2 = count_1 <= ω;
 
   for (size_t i = 0; i < 32; i++) {
-    flg1 |= static_cast<bool>(sig[sigoff2 + i] ^ hash_out[i]);
+    flg1 |= static_cast<bool>(sig[sigoff0 + i] ^ hash_out[i]);
   }
 
   const bool flg3 = flg0 & !flg1 & flg2;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -42,12 +42,11 @@ main()
     using namespace test_dilithium;
 
     // NIST security level 2, 3, 5 ( in order )
-    test_signing<4, 4, 13, 2, 1u << 17, (ff::Q - 1) / 88, 39, 78, 80>();
-    test_signing<6, 5, 13, 4, 1u << 19, (ff::Q - 1) / 32, 49, 196, 55>();
-    test_signing<8, 7, 13, 2, 1u << 19, (ff::Q - 1) / 32, 60, 120, 75>();
+    test_signing<4, 4, 13, 2, 1u << 17, (ff::Q - 1) / 88, 39, 78, 80>(33);
+    test_signing<6, 5, 13, 4, 1u << 19, (ff::Q - 1) / 32, 49, 196, 55>(37);
+    test_signing<8, 7, 13, 2, 1u << 19, (ff::Q - 1) / 32, 60, 120, 75>(43);
 
-    std::cout
-      << "[test] Dilithium-{2, 3, 5} KeyGen -> Signing -> Verification\n";
+    std::cout << "[test] Dilithium KeyGen -> Signing -> Verification\n";
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
This PR updates Dilithium 

- key generation
- signing
- verification

algorithm to latest specification version, which can be found [here](https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf).

> **Note**
> Once this PR gets merged, this Dilithium implementation is conformant to latest specification. 

---

Now benchmarking on **Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz**,  looks like

```bash
make benchmark

2022-10-28T13:06:48+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 1.60, 2.07, 2.12
------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------
bench_dilithium::ff_add                                     3.74 ns         3.73 ns    186185068
bench_dilithium::ff_sub                                     3.71 ns         3.71 ns    189072680
bench_dilithium::ff_neg                                     1.24 ns         1.24 ns    554617987
bench_dilithium::ff_mul                                     5.99 ns         5.98 ns    115932428
bench_dilithium::ff_inv                                     89.8 ns         89.7 ns     12297746
bench_dilithium::ff_div                                     79.4 ns         79.3 ns      9550838
bench_dilithium::ff_exp                                      316 ns          316 ns      2109482
bench_dilithium::ntt                                        4658 ns         4655 ns       150644
bench_dilithium::intt                                       4373 ns         4370 ns       160925
bench_dilithium::power2round                                2.35 ns         2.35 ns    295589384
bench_dilithium::decompose<190464>                          8.31 ns         8.31 ns     81635509
bench_dilithium::make_hint<190464>                          13.5 ns         13.5 ns     51527041
bench_dilithium::use_hint<190464>                           7.97 ns         7.96 ns     87457365
bench_dilithium::decompose<523776>                          8.75 ns         8.75 ns     77321580
bench_dilithium::make_hint<523776>                          14.6 ns         14.6 ns     47119326
bench_dilithium::use_hint<523776>                           8.39 ns         8.39 ns     82670005
bench_dilithium::expand_a<4, 4>                            53018 ns        52969 ns        12807
bench_dilithium::expand_a<6, 5>                            97270 ns        97206 ns         7059
bench_dilithium::expand_a<8, 7>                           184876 ns       184790 ns         3757
bench_dilithium::expand_s<2, 4>                             6901 ns         6897 ns        98835
bench_dilithium::expand_s<2, 8>                            14553 ns        14545 ns        46497
bench_dilithium::expand_s<4, 6>                            16202 ns        16195 ns        42226
bench_dilithium::expand_mask<1u << 17, 4>                  30737 ns        30690 ns        22777
bench_dilithium::expand_mask<1u << 19, 5>                  41187 ns        41171 ns        16916
bench_dilithium::expand_mask<1u << 19, 7>                  57651 ns        57616 ns        11639
bench_dilithium::sample_in_ball<39>                          610 ns          609 ns      1121507
bench_dilithium::sample_in_ball<49>                          667 ns          667 ns      1056014
bench_dilithium::sample_in_ball<60>                          778 ns          778 ns       837150
bench_dilithium::encode<3>                                   971 ns          971 ns       721114
bench_dilithium::decode<3>                                  1017 ns         1017 ns       680735
bench_dilithium::encode<4>                                   833 ns          833 ns       830259
bench_dilithium::decode<4>                                  1032 ns         1031 ns       673608
bench_dilithium::encode<6>                                  1734 ns         1726 ns       394891
bench_dilithium::decode<6>                                  1840 ns         1836 ns       369019
bench_dilithium::encode<10>                                 2921 ns         2914 ns       240742
bench_dilithium::decode<10>                                 3127 ns         3123 ns       222887
bench_dilithium::encode<13>                                 4318 ns         4315 ns       162915
bench_dilithium::decode<13>                                 4668 ns         4663 ns       150398
bench_dilithium::encode<18>                                 5017 ns         5015 ns       135648
bench_dilithium::decode<18>                                 5800 ns         5797 ns       117647
bench_dilithium::encode<20>                                 5520 ns         5517 ns       118833
bench_dilithium::decode<20>                                 6446 ns         6443 ns       105895
bench_dilithium::encode_hint_bits<4, 80>                    1636 ns         1634 ns       422017
bench_dilithium::decode_hint_bits<4, 80>                     104 ns          104 ns      6526989
bench_dilithium::encode_hint_bits<6, 55>                    2676 ns         2674 ns       276703
bench_dilithium::decode_hint_bits<6, 55>                     106 ns          106 ns      6296153
bench_dilithium::encode_hint_bits<8, 75>                    3430 ns         3425 ns       198282
bench_dilithium::decode_hint_bits<8, 75>                     143 ns          143 ns      4827187
keygen<4, 4, 13, 2>/32                                    155013 ns       154976 ns         4457 items_per_second=6.45259k/s
sign<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>/32         516358 ns       516001 ns          987 items_per_second=1.93798k/s
verify<4, 4, 13, 2, 1u << 17, 95232, 39, 78, 80>/32       185567 ns       185444 ns         3738 items_per_second=5.39246k/s
keygen<6, 5, 13, 4>/32                                    252139 ns       251932 ns         2768 items_per_second=3.96932k/s
sign<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>/32       733283 ns       732977 ns          704 items_per_second=1.3643k/s
verify<6, 5, 13, 4, 1u << 19, 261888, 49, 196, 55>/32     279249 ns       279095 ns         2503 items_per_second=3.583k/s
keygen<8, 7, 13, 2>/32                                    386520 ns       386242 ns         1802 items_per_second=2.58905k/s
sign<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>/32      2714116 ns      2713065 ns          650 items_per_second=368.587/s
verify<8, 7, 13, 2, 1u << 19, 261888, 60, 120, 75>/32     436436 ns       436135 ns         1602 items_per_second=2.29287k/s
```