### PR TITLE
Remove Redundant `const`s

### DIFF
--- a/include/bit_packing.hpp
+++ b/include/bit_packing.hpp
@@ -15,7 +15,7 @@ namespace bit_packing {
 //
 // See section 5.2 ( which describes bit packing ) of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t sbw>
+template<size_t sbw>
 static inline constexpr void
 encode(std::span<const field::zq_t, ntt::N> poly, std::span<uint8_t, ntt::N * sbw / 8> arr)
   requires(dilithium_params::check_sbw(sbw))
@@ -184,7 +184,7 @@ encode(std::span<const field::zq_t, ntt::N> poly, std::span<uint8_t, ntt::N * sb
 // This is just the opposite of above `encode` routine. You may want to see
 // Dilithium specification's section 5.2
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t sbw>
+template<size_t sbw>
 static inline constexpr void
 decode(std::span<const uint8_t, ntt::N * sbw / 8> arr, std::span<field::zq_t, ntt::N> poly)
   requires(dilithium_params::check_sbw(sbw))
@@ -331,7 +331,7 @@ decode(std::span<const uint8_t, ntt::N * sbw / 8> arr, std::span<field::zq_t, nt
 // bits into (ω + k) -bytes, following the description in section 5.4 ( see
 // point `Signature` on page 21 ) of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k, const size_t ω>
+template<size_t k, size_t ω>
 static inline constexpr void
 encode_hint_bits(std::span<const field::zq_t, k * ntt::N> h, std::span<uint8_t, ω + k> arr)
 {
@@ -361,7 +361,7 @@ encode_hint_bits(std::span<const field::zq_t, k * ntt::N> h, std::span<uint8_t, 
 // Returns boolean result denoting status of decoding of byte serialized hint
 // bits. For example, say return value is true, it denotes that decoding has
 // failed.
-template<const size_t k, const size_t ω>
+template<size_t k, size_t ω>
 static inline constexpr bool
 decode_hint_bits(std::span<const uint8_t, ω + k> arr, std::span<field::zq_t, k * ntt::N> h)
 {

--- a/include/dilithium.hpp
+++ b/include/dilithium.hpp
@@ -21,7 +21,7 @@ namespace dilithium {
 // Note, ebw = ceil(log2(2 * η + 1))
 //
 // See section 5.4 of specification for public key and secret key byte length.
-template<const size_t k, const size_t l, const size_t d, const uint32_t η>
+template<size_t k, size_t l, size_t d, uint32_t η>
 static inline void
 keygen(std::span<const uint8_t, 32> seed,
        std::span<uint8_t, dilithium_utils::pub_key_len<k, d>()> pubkey,
@@ -133,16 +133,16 @@ keygen(std::span<const uint8_t, 32> seed,
 //
 // See section 5.4 of specification for understanding how signature is byte
 // serialized.
-template<const size_t k,
-         const size_t l,
-         const size_t d,
-         const uint32_t η,
-         const uint32_t γ1,
-         const uint32_t γ2,
-         const uint32_t τ,
-         const uint32_t β,
-         const size_t ω,
-         const bool randomized = false>
+template<size_t k,
+         size_t l,
+         size_t d,
+         uint32_t η,
+         uint32_t γ1,
+         uint32_t γ2,
+         uint32_t τ,
+         uint32_t β,
+         size_t ω,
+         bool randomized = false>
 static inline void
 sign(std::span<const uint8_t, dilithium_utils::sec_key_len<k, l, η, d>()> seckey,
      std::span<const uint8_t> msg,
@@ -323,14 +323,7 @@ sign(std::span<const uint8_t, dilithium_utils::sec_key_len<k, l, η, d>()> secke
 //
 // Verification algorithm is described in figure 4 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k,
-         const size_t l,
-         const size_t d,
-         const uint32_t γ1,
-         const uint32_t γ2,
-         const uint32_t τ,
-         const uint32_t β,
-         const size_t ω>
+template<size_t k, size_t l, size_t d, uint32_t γ1, uint32_t γ2, uint32_t τ, uint32_t β, size_t ω>
 static inline bool
 verify(std::span<const uint8_t, dilithium_utils::pub_key_len<k, d>()> pubkey,
        std::span<const uint8_t> msg,

--- a/include/ntt.hpp
+++ b/include/ntt.hpp
@@ -25,7 +25,7 @@ constexpr auto INV_N = field::zq_t(N).inv();
 // See
 // https://github.com/itzmeanjan/kyber/blob/3cd41a5/include/ntt.hpp#L74-L93
 // for source of inspiration.
-template<const size_t mbw>
+template<size_t mbw>
 static inline constexpr size_t
 bit_rev(const size_t v)
   requires(mbw == LOG2N)

--- a/include/poly.hpp
+++ b/include/poly.hpp
@@ -11,7 +11,7 @@ namespace poly {
 
 // Given a degree-255 polynomial over Z_q | q = 2^23 - 2^13 + 1, this routine
 // attempts to extract out high and low order bits from each of 256 coefficients
-template<const size_t d>
+template<size_t d>
 static inline constexpr void
 power2round(std::span<const field::zq_t, ntt::N> poly,
             std::span<field::zq_t, ntt::N> poly_hi,
@@ -40,7 +40,7 @@ mul(std::span<const field::zq_t, ntt::N> polya,
 
 // Given a degree-255 polynomial, which has all of its coefficients in [-x, x],
 // this routine subtracts each coefficient from x, so that they stay in [0, 2x].
-template<const uint32_t x>
+template<uint32_t x>
 static inline constexpr void
 sub_from_x(std::span<field::zq_t, ntt::N> poly)
 {
@@ -53,7 +53,7 @@ sub_from_x(std::span<field::zq_t, ntt::N> poly)
 
 // Given a degree-255 polynomial, this routine extracts out high order bits (
 // using decompose routine ), while not mutating source polynomial
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr void
 highbits(std::span<const field::zq_t, ntt::N> src, std::span<field::zq_t, ntt::N> dst)
 {
@@ -64,7 +64,7 @@ highbits(std::span<const field::zq_t, ntt::N> src, std::span<field::zq_t, ntt::N
 
 // Given a degree-255 polynomial, this routine extracts out low order bits (
 // using decompose routine ), while not mutating source polynomial
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr void
 lowbits(std::span<const field::zq_t, ntt::N> src, std::span<field::zq_t, ntt::N> dst)
 {
@@ -95,7 +95,7 @@ infinity_norm(std::span<const field::zq_t, ntt::N> poly)
 
 // Given two degree-255 polynomials, this routine computes hint bit for each
 // coefficient, using `make_hint` routine.
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr void
 make_hint(std::span<const field::zq_t, ntt::N> polya,
           std::span<const field::zq_t, ntt::N> polyb,
@@ -110,7 +110,7 @@ make_hint(std::span<const field::zq_t, ntt::N> polya,
 // polynomial r with arbitrary coefficients ∈ Z_q, this routine recovers high
 // order bits of r + z s.t. hint bit was computed using `make_hint` routine and
 // z is another degree-255 polynomial with small coefficients.
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr void
 use_hint(std::span<const field::zq_t, ntt::N> polyh,
          std::span<const field::zq_t, ntt::N> polyr,
@@ -138,7 +138,7 @@ count_1s(std::span<const field::zq_t, ntt::N> poly)
 
 // Given a degree-255 polynomial, this routine shifts each coefficient
 // leftwards, by d bits
-template<const size_t d>
+template<size_t d>
 static inline constexpr void
 shl(std::span<field::zq_t, ntt::N> poly)
 {

--- a/include/polyvec.hpp
+++ b/include/polyvec.hpp
@@ -14,7 +14,7 @@ using const_poly_t = std::span<const field::zq_t, ntt::N>;
 using poly_t = std::span<field::zq_t, ntt::N>;
 
 // Applies NTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
-template<const size_t k>
+template<size_t k>
 static inline constexpr void
 ntt(std::span<field::zq_t, k * ntt::N> vec)
 {
@@ -25,7 +25,7 @@ ntt(std::span<field::zq_t, k * ntt::N> vec)
 }
 
 // Applies iNTT on a vector ( of dimension k x 1 ) of degree-255 polynomials
-template<const size_t k>
+template<size_t k>
 static inline constexpr void
 intt(std::span<field::zq_t, k * ntt::N> vec)
 {
@@ -37,7 +37,7 @@ intt(std::span<field::zq_t, k * ntt::N> vec)
 
 // Compresses vector ( of dimension k x 1 ) of degree-255 polynomials by
 // extracting out high and low order bits
-template<const size_t k, const size_t d>
+template<size_t k, size_t d>
 static inline constexpr void
 power2round(std::span<const field::zq_t, k * ntt::N> poly,
             std::span<field::zq_t, k * ntt::N> poly_hi,
@@ -55,7 +55,7 @@ power2round(std::span<const field::zq_t, k * ntt::N> poly,
 // Given two matrices ( in NTT domain ) of compatible dimension, where each
 // matrix element is a degree-255 polynomial over Z_q | q = 2^23 -2^13 + 1, this
 // routine attempts to multiply and compute resulting matrix
-template<const size_t a_rows, const size_t a_cols, const size_t b_rows, const size_t b_cols>
+template<size_t a_rows, size_t a_cols, size_t b_rows, size_t b_cols>
 static inline constexpr void
 matrix_multiply(std::span<const field::zq_t, a_rows * a_cols * ntt::N> a,
                 std::span<const field::zq_t, b_rows * b_cols * ntt::N> b,
@@ -86,7 +86,7 @@ matrix_multiply(std::span<const field::zq_t, a_rows * a_cols * ntt::N> a,
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this
 // routine adds it to another polynomial vector of same dimension s.t.
 // destination vector is mutated.
-template<const size_t k>
+template<size_t k>
 static inline constexpr void
 add_to(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k * ntt::N> dst)
 {
@@ -101,7 +101,7 @@ add_to(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k * 
 
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this
 // routine negates each coefficient.
-template<const size_t k>
+template<size_t k>
 static inline constexpr void
 neg(std::span<field::zq_t, k * ntt::N> vec)
 {
@@ -117,7 +117,7 @@ neg(std::span<field::zq_t, k * ntt::N> vec)
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials s.t. each
 // coefficient ∈ [-x, x], this routine subtracts each coefficient from x so that
 // coefficients now stay in [0, 2x].
-template<const size_t k, const uint32_t x>
+template<size_t k, uint32_t x>
 static inline constexpr void
 sub_from_x(std::span<field::zq_t, k * ntt::N> vec)
 {
@@ -130,7 +130,7 @@ sub_from_x(std::span<field::zq_t, k * ntt::N> vec)
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
 // encodes each of those polynomials into 32 x sbw -bytes, writing to a
 // (k x 32 x sbw) -bytes destination array.
-template<const size_t k, const size_t sbw>
+template<size_t k, size_t sbw>
 static inline constexpr void
 encode(std::span<const field::zq_t, k * ntt::N> src, std::span<uint8_t, k * sbw * ntt::N / 8> dst)
 {
@@ -149,7 +149,7 @@ encode(std::span<const field::zq_t, k * ntt::N> src, std::span<uint8_t, k * sbw 
 // Given a byte array of length (k x 32 x sbw) -bytes, this routine decodes them
 // into k degree-255 polynomials, writing them to a column vector of dimension
 // k x 1.
-template<const size_t k, const size_t sbw>
+template<size_t k, size_t sbw>
 static inline constexpr void
 decode(std::span<const uint8_t, k * sbw * ntt::N / 8> src, std::span<field::zq_t, k * ntt::N> dst)
 {
@@ -167,7 +167,7 @@ decode(std::span<const uint8_t, k * sbw * ntt::N / 8> src, std::span<field::zq_t
 
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
 // extracts out high order bits from each coefficient
-template<const size_t k, const uint32_t alpha>
+template<size_t k, uint32_t alpha>
 static inline constexpr void
 highbits(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k * ntt::N> dst)
 {
@@ -179,7 +179,7 @@ highbits(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k 
 
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
 // extracts out low order bits from each coefficient, while not mutating operand
-template<const size_t k, const uint32_t alpha>
+template<size_t k, uint32_t alpha>
 static inline constexpr void
 lowbits(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k * ntt::N> dst)
 {
@@ -193,7 +193,7 @@ lowbits(std::span<const field::zq_t, k * ntt::N> src, std::span<field::zq_t, k *
 // multiplier polynomial, this routine performs k pointwise polynomial
 // multiplications when each of these polynomials are in their NTT
 // representation, while not mutating operand polynomials.
-template<const size_t k>
+template<size_t k>
 static inline constexpr void
 mul_by_poly(std::span<const field::zq_t, ntt::N> poly,
             std::span<const field::zq_t, k * ntt::N> src_vec,
@@ -210,7 +210,7 @@ mul_by_poly(std::span<const field::zq_t, ntt::N> poly,
 //
 // See point `Sizes of elements` in section 2.1 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k>
+template<size_t k>
 static inline constexpr field::zq_t
 infinity_norm(std::span<const field::zq_t, k * ntt::N> vec)
 {
@@ -226,7 +226,7 @@ infinity_norm(std::span<const field::zq_t, k * ntt::N> vec)
 
 // Given two vector ( of dimension k x 1 ) of degree-255 polynomials, this
 // routine computes hint bit for each coefficient, using `make_hint` routine.
-template<const size_t k, const uint32_t alpha>
+template<size_t k, uint32_t alpha>
 static inline constexpr void
 make_hint(std::span<const field::zq_t, k * ntt::N> polya,
           std::span<const field::zq_t, k * ntt::N> polyb,
@@ -243,7 +243,7 @@ make_hint(std::span<const field::zq_t, k * ntt::N> polya,
 // Recovers high order bits of a vector of degree-255 polynomials (  i.e. r + z
 // ) s.t. hint bits ( say h ) and another polynomial vector ( say r ) are
 // provided.
-template<const size_t k, const uint32_t alpha>
+template<size_t k, uint32_t alpha>
 static inline constexpr void
 use_hint(std::span<const field::zq_t, k * ntt::N> polyh,
          std::span<const field::zq_t, k * ntt::N> polyr,
@@ -259,7 +259,7 @@ use_hint(std::span<const field::zq_t, k * ntt::N> polyh,
 
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
 // counts number of coefficients having value 1.
-template<const size_t k>
+template<size_t k>
 static inline constexpr size_t
 count_1s(std::span<const field::zq_t, k * ntt::N> vec)
 {
@@ -275,7 +275,7 @@ count_1s(std::span<const field::zq_t, k * ntt::N> vec)
 
 // Given a vector ( of dimension k x 1 ) of degree-255 polynomials, this routine
 // shifts each coefficient leftwards by d bits
-template<const size_t k, const size_t d>
+template<size_t k, size_t d>
 static inline constexpr void
 shl(std::span<field::zq_t, k * ntt::N> vec)
 {

--- a/include/reduction.hpp
+++ b/include/reduction.hpp
@@ -19,7 +19,7 @@ namespace reduction {
 //
 // This implementation collects some ideas from
 // https://github.com/pq-crystals/dilithium/blob/3e9b9f1/ref/rounding.c#L5-L23
-template<const size_t d>
+template<size_t d>
 static inline constexpr std::pair<field::zq_t, field::zq_t>
 power2round(const field::zq_t r)
   requires(dilithium_params::check_d(d))
@@ -45,7 +45,7 @@ power2round(const field::zq_t r)
 //
 // See definition of this routine in figure 3 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr std::pair<field::zq_t, field::zq_t>
 decompose(const field::zq_t r)
   requires(dilithium_params::check_γ2(alpha / 2))
@@ -74,7 +74,7 @@ decompose(const field::zq_t r)
 //
 // See definition of this routine in figure 3 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr field::zq_t
 highbits(const field::zq_t r)
 {
@@ -87,7 +87,7 @@ highbits(const field::zq_t r)
 //
 // See definition of this routine in figure 3 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr field::zq_t
 lowbits(const field::zq_t r)
 {
@@ -103,7 +103,7 @@ lowbits(const field::zq_t r)
 //
 // See definition of this routine in figure 3 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr field::zq_t
 make_hint(const field::zq_t z, const field::zq_t r)
 {
@@ -118,7 +118,7 @@ make_hint(const field::zq_t z, const field::zq_t r)
 //
 // See definition of this routine in figure 3 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha>
+template<uint32_t alpha>
 static inline constexpr field::zq_t
 use_hint(const field::zq_t h, const field::zq_t r)
 {

--- a/include/sampling.hpp
+++ b/include/sampling.hpp
@@ -15,15 +15,14 @@ namespace sampling {
 
 using poly_t = std::span<field::zq_t, ntt::N>;
 
-// Given a 32 -bytes uniform seed ρ, a k x l matrix is deterministically
-// sampled, where each coefficient is a degree-255 polynomial ∈ R_q
-// | q = 2^23 - 2^13 + 1
+// Given a 32 -bytes uniform seed ρ, a k x l matrix is deterministically sampled ( using the method of rejection
+// sampling ), where each coefficient is a degree-255 polynomial ∈ R_q | q = 2^23 - 2^13 + 1
 //
 // Shake128 Xof is used for expanding 32 -bytes seed to matrix over R_q^(k x l).
 //
 // See `Expanding the Matrix A` point in section 5.3 of Dilithium specification,
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k, const size_t l>
+template<size_t k, size_t l>
 static inline constexpr void
 expand_a(std::span<const uint8_t, 32> rho, std::span<field::zq_t, k * l * ntt::N> mat)
 {
@@ -67,7 +66,7 @@ expand_a(std::span<const uint8_t, 32> rho, std::span<field::zq_t, k * l * ntt::N
   }
 }
 
-// Uniform sampling k -many degree-255 polynomials s.t. each coefficient of
+// Uniform rejection sampling k -many degree-255 polynomials s.t. each coefficient of
 // those polynomials ∈ [-η, η].
 //
 // Sampling is performed deterministically, by seeding Shake256 Xof with
@@ -78,9 +77,8 @@ expand_a(std::span<const uint8_t, 32> rho, std::span<field::zq_t, k * l * ntt::N
 // Note, sampled polynomial coefficients are kept in canonical form.
 //
 // See `Sampling the vectors s1 and s2` point in section 5.3 of Dilithium
-// specification
-// https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t η, const size_t k, const uint16_t nonce>
+// specification https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
+template<uint32_t η, size_t k, uint16_t nonce>
 static inline constexpr void
 expand_s(std::span<const uint8_t, 64> rho_prime, std::span<field::zq_t, k * ntt::N> vec)
   requires(dilithium_params::check_η(η) && dilithium_params::check_nonce(nonce))
@@ -152,7 +150,7 @@ expand_s(std::span<const uint8_t, 64> rho_prime, std::span<field::zq_t, k * ntt:
 // See `Sampling the vectors y` point in section 5.3 of Dilithium
 // specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t γ1, const size_t l>
+template<uint32_t γ1, size_t l>
 static inline constexpr void
 expand_mask(std::span<const uint8_t, 64> seed, const uint16_t nonce, std::span<field::zq_t, l * ntt::N> vec)
   requires(dilithium_params::check_γ1(γ1))
@@ -190,7 +188,7 @@ expand_mask(std::span<const uint8_t, 64> seed, const uint16_t nonce, std::span<f
 // See hashing to a ball algorithm described in figure 2 and section 5.3 of
 // Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t τ>
+template<uint32_t τ>
 static inline constexpr void
 sample_in_ball(std::span<const uint8_t, 32> seed, std::span<field::zq_t, ntt::N> poly)
   requires(dilithium_params::check_τ(τ))

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -15,7 +15,7 @@ namespace dilithium_utils {
 //
 // See table 2 and section 5.4 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k, const size_t d>
+template<size_t k, size_t d>
 static inline constexpr size_t
 pub_key_len()
   requires(dilithium_params::check_d(d))
@@ -30,7 +30,7 @@ pub_key_len()
 //
 // See table 2 and section 5.4 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k, const size_t l, const uint32_t η, const size_t d>
+template<size_t k, size_t l, uint32_t η, size_t d>
 static inline constexpr size_t
 sec_key_len()
   requires(dilithium_params::check_d(d))
@@ -45,7 +45,7 @@ sec_key_len()
 //
 // See table 2 and section 5.4 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const size_t k, const size_t l, const uint32_t γ1, const size_t ω>
+template<size_t k, size_t l, uint32_t γ1, size_t ω>
 static inline constexpr size_t
 sig_len()
 {

--- a/tests/test_bit_packing.cpp
+++ b/tests/test_bit_packing.cpp
@@ -8,7 +8,7 @@
 //
 // - polynomial to byte array encoding
 // - decoding of polynomial from byte array
-template<const size_t sbw>
+template<size_t sbw>
 void
 test_encode_decode()
   requires(dilithium_params::check_sbw(sbw))
@@ -56,7 +56,7 @@ TEST(Dilithium, PolynomialEncodingDecoding)
 
 // Generates random hint bit polynomial vector of dimension k x 1, with <= ω
 // coefficients set to 1.
-template<const size_t k, const size_t ω>
+template<size_t k, size_t ω>
 void
 generate_random_hint_bits(std::span<field::zq_t, k * ntt::N> poly)
 {
@@ -77,7 +77,7 @@ generate_random_hint_bits(std::span<field::zq_t, k * ntt::N> poly)
 
 // Test functional correctness of encoding and decoding of hint bit polynomial
 // vector.
-template<const size_t k, const size_t ω>
+template<size_t k, size_t ω>
 void
 test_encode_decode_hint_bits()
 {

--- a/tests/test_ntt.cpp
+++ b/tests/test_ntt.cpp
@@ -29,11 +29,5 @@ TEST(Dilithium, NumberTheoreticTransform)
   ntt::ntt(_poly_b);
   ntt::intt(_poly_b);
 
-  bool flg = true;
-
-  for (size_t i = 0; i < ntt::N; i++) {
-    flg &= (_poly_a[i] == _poly_b[i]);
-  }
-
-  EXPECT_TRUE(flg);
+  EXPECT_EQ(poly_a, poly_b);
 }

--- a/tests/test_reduction.cpp
+++ b/tests/test_reduction.cpp
@@ -30,7 +30,7 @@ TEST(Dilithium, Power2Round)
 //
 // Read section 2.4 of Dilithium specification
 // https://pq-crystals.org/dilithium/data/dilithium-specification-round3-20210208.pdf
-template<const uint32_t alpha, const uint32_t z, const size_t rounds = 65536ul>
+template<uint32_t alpha, uint32_t z, size_t rounds = 65536ul>
 static void
 test_decompose()
 {

--- a/tests/test_sampling.cpp
+++ b/tests/test_sampling.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 // Check whether hashing to a ball routine works as expected or not.
-template<const uint32_t τ>
+template<uint32_t τ>
 static void
 test_sample_in_ball()
 {


### PR DESCRIPTION
Get rid of redundant `const`s in template parameters.
